### PR TITLE
Boost boss experience rewards

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -1433,6 +1433,24 @@
         });
       }
 
+      function dropExpOrbs(e) {
+        const x = e.x + e.w / 2;
+        const y = e.y + e.h / 2;
+        let count = 1;
+        if (e.isBoss) {
+          if (currentWave === 3) {
+            count = 20;
+          } else if (currentWave === 7) {
+            count = 40;
+          } else if (currentWave === 11) {
+            count = 80;
+          }
+        }
+        for (let i = 0; i < count; i++) {
+          spawnExpOrb(x, y);
+        }
+      }
+
       function findNearestEnemy(px, py) {
         let nearest = null;
         let best = Infinity;
@@ -1467,7 +1485,7 @@
             e.hp -= dmg;
             spawnFloatText(ex, ey - 12, -dmg, "#ff6b6b");
             if (e.hp <= 0) {
-              spawnExpOrb(e.x + e.w / 2, e.y + e.h / 2);
+              dropExpOrbs(e);
               enemies.splice(i, 1);
               score += e.reward;
             }
@@ -1499,7 +1517,7 @@
             e.hp -= dmg;
             spawnFloatText(e.x + e.w / 2, e.y - 12, -dmg, "#ff6b6b");
             if (e.hp <= 0) {
-              spawnExpOrb(e.x + e.w / 2, e.y + e.h / 2);
+              dropExpOrbs(e);
               enemies.splice(i, 1);
               score += e.reward;
               continue;
@@ -1950,7 +1968,7 @@
             e.hp -= dmg;
             spawnFloatText(e.x + e.w / 2, e.y - 12, -dmg, "#60a5fa");
             if (e.hp <= 0) {
-              spawnExpOrb(e.x + e.w / 2, e.y + e.h / 2);
+              dropExpOrbs(e);
               enemies.splice(i, 1);
               score += e.reward;
               e._killed = true;
@@ -2015,7 +2033,7 @@
 
               if (e.hp <= 0) {
                 // 경험치 구슬 드롭
-                spawnExpOrb(e.x + e.w / 2, e.y + e.h / 2);
+                dropExpOrbs(e);
                 enemies.splice(i, 1);
                 score += e.reward;
                 e._killed = true;
@@ -2047,7 +2065,7 @@
 
               spawnFloatText(e.x + e.w / 2, e.y - 12, -dmg, "#ff6b6b");
               if (e.hp <= 0) {
-                spawnExpOrb(e.x + e.w / 2, e.y + e.h / 2);
+                dropExpOrbs(e);
                 enemies.splice(i, 1);
                 score += e.reward;
                 e._killed = true;


### PR DESCRIPTION
## Summary
- Introduced `dropExpOrbs` to spawn extra experience orbs on enemy death
- Bosses now drop 20/40/80 orbs on waves 4/8/12 for increased rewards
- Replaced direct orb spawning calls with new helper

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bed3f6bbcc83329c2399b39efe8b95