### PR TITLE
Scale exp orb drops by enemy tier

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -1529,7 +1529,8 @@
       function dropExpOrbs(e) {
         const x = e.x + e.w / 2;
         const y = e.y + e.h / 2;
-        let count = 1;
+        // 기본 드랍량은 적의 등급(exp)에 비례시킨다
+        let count = (e.tier && e.tier.exp) ? e.tier.exp : 1;
         if (e.isBoss) {
           if (currentWave === 3) {
             count = 20;


### PR DESCRIPTION
## Summary
- Increase exp orb drop count based on each enemy's tier exp value

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68bfabf1e1ec8332bb1c9f73d5c84ce4