### PR TITLE
Show upgrade limits in selection screen

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -2133,8 +2133,9 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         selected.forEach(upgrade => {
           const btn = document.createElement("div");
           btn.className = "upgrade-btn";
+          const current = acquiredUpgrades[upgrade.id] || 0;
           btn.innerHTML = `
-            <div class="upgrade-title">${upgrade.icon} ${upgrade.title}</div>
+            <div class="upgrade-title">${upgrade.icon} ${upgrade.title} (${current}/${upgrade.limit})</div>
             <div class="upgrade-desc">${upgrade.desc}</div>
         `;
           btn.onclick = () => {


### PR DESCRIPTION
## Summary
- Display current and maximum counts for each upgrade option on the level-up screen

## Testing
- `npx --yes htmlhint warigari_surviver.html` (fails: 403 Forbidden)
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c22850f63083328b7ce4f96fcd2304