### PR TITLE
Spawn enemies off-screen

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -1871,6 +1871,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         });
         for (let i = enemies.length - 1; i >= 0; i--) {
           const e = enemies[i];
+          if (!e.entered) continue;
           const ex = e.x + e.w / 2;
           const ey = e.y + e.h / 2;
           const dist = Math.hypot(ex - b.x, ey - b.y);
@@ -1901,6 +1902,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         });
         for (let i = enemies.length - 1; i >= 0; i--) {
           const e = enemies[i];
+          if (!e.entered) continue;
           const ex = e.x + e.w / 2;
           const ey = e.y + e.h / 2;
           const dx = ex - px;
@@ -1944,6 +1946,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         });
         for (let i = enemies.length - 1; i >= 0; i--) {
           const e = enemies[i];
+          if (!e.entered) continue;
           const ex = e.x + e.w / 2;
           const ey = e.y + e.h / 2;
           const dx = ex - px;


### PR DESCRIPTION
## Summary
- Spawn enemies outside the viewport and mark them until fully entering the play area
- Clamp enemy positions only after they appear on screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c22f402ec08332920e29c4c77c81e7