### PR TITLE
feat: make yoyo return when player turns

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -2526,6 +2526,8 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             y.vx = dir * yoyoSpeed;
             if (Math.abs(targetX - y.x) <= Math.abs(y.vx * dt)) {
               yoyos.splice(i, 1);
+              // 요요가 즉시 재사용되도록 쿨다운을 채워준다
+              yoyoTimer = yoyoCooldown;
               continue;
             }
           }


### PR DESCRIPTION
## Summary
- make thrown yoyo immediately return when player reverses direction

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c253be8e608332a4d6bd4e9e3429d3