### PR TITLE
feat: separate start and restart panels

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -1147,7 +1147,8 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           } else if (!spaceLocked) {
             spaceLocked = true;
             if (!running) {
-              startGame(baseAttack);
+              overlay.style.display = "none";
+              showWeaponSelectScreen();
             } else if (!paused) {
               toggleDirection();
             }


### PR DESCRIPTION
## Summary
- decouple weapon selection from start and restart screens
- add dedicated start screen and game over screen
- start/restart buttons lead to weapon selection before gameplay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c25948ce38833281e7997c07e5a0c4