### PR TITLE
feat: add yoyo-colored snapback

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -3146,28 +3146,55 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         ctx.quadraticCurveTo(player.x, player.y, player.x + radius, player.y);
         ctx.fill();
 
-        // 스냅백 (요요 기본 공격 시)
+        // 캡 (요요 기본 공격 시)
         if (baseAttack === "yoyo") {
           ctx.fillStyle = yoyoColor;
-          const capRadius = player.w / 2;
+          const dir = player.dir;
+          const capWidth = player.w * 0.9;
+          const capHeight = player.h * 0.5;
+
+          ctx.save();
+          if (dir < 0) {
+            ctx.translate(player.x + player.w, 0);
+            ctx.scale(-1, 1);
+          }
+
+          const capX = player.x + player.w * 0.05;
+          const capY = player.y - capHeight;
+
+          // 모자 본체
           ctx.beginPath();
-          ctx.arc(
-            player.x + capRadius,
-            player.y,
-            capRadius,
-            Math.PI,
-            0,
-            true,
+          ctx.moveTo(capX, capY + capHeight);
+          ctx.quadraticCurveTo(
+            capX + capWidth * 0.2,
+            capY,
+            capX + capWidth * 0.8,
+            capY + capHeight * 0.2,
           );
+          ctx.quadraticCurveTo(
+            capX + capWidth,
+            capY + capHeight * 0.3,
+            capX + capWidth * 0.9,
+            capY + capHeight,
+          );
+          ctx.closePath();
           ctx.fill();
-          const brimWidth = player.w * 0.6;
-          const brimHeight = 3;
-          ctx.fillRect(
-            player.x + (player.w - brimWidth) / 2,
-            player.y,
-            brimWidth,
-            brimHeight,
+
+          // 챙
+          ctx.beginPath();
+          const brimStartX = capX + capWidth;
+          const brimStartY = player.y - capHeight * 0.1;
+          ctx.moveTo(brimStartX, brimStartY);
+          ctx.quadraticCurveTo(
+            brimStartX + capWidth * 0.6,
+            brimStartY + capHeight * 0.15,
+            brimStartX,
+            brimStartY + capHeight * 0.3,
           );
+          ctx.closePath();
+          ctx.fill();
+
+          ctx.restore();
         }
 
         // 눈 (방향에 따라 위치 변경)


### PR DESCRIPTION
## Summary
- draw player wearing snapback matching yoyo color when using yoyo basic attack
- centralize yoyo color configuration

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ce97cc788332b0103c31b9721e95