### PR TITLE
fix: ensure yoyo kills enemies at zero HP

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -2889,6 +2889,13 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
                 }
 
                 y.hitSet.add(e.id);
+                if (e.hp <= 0) {
+                  dropExpOrbs(e);
+                  enemies.splice(i, 1);
+                  score += e.reward;
+                  e._killed = true;
+                  break;
+                }
               }
             }
             if (e._killed) continue;


### PR DESCRIPTION
## Summary
- ensure yoyo collision checks for enemy death and cleans up

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e38e45388332ab47a68ee1e88870