### PR TITLE
Increase enemy speed randomness to ±10%

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -1554,7 +1554,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         const scale = enemyScale;
         const hpBase =
           tier.hp * scale * type.hpMul * (1 + (Math.random() * 0.2 - 0.1));
-        const speedMul = type.speedMul * (1 + (Math.random() * 0.1 - 0.05));
+        const speedMul = type.speedMul * (1 + (Math.random() * 0.2 - 0.1));
         enemies.push({
           id: nextEnemyId++,
           x: spawnX,


### PR DESCRIPTION
## Summary
- Expand enemy speed variance to -10% to +10%

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e6e343b48332a0b1a76678d957ec