### PR TITLE
feat: change sword warning glow color

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -3233,13 +3233,13 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           ctx.translate(cx, cy);
           ctx.scale(player.dir, 1);
           ctx.rotate(-11 * Math.PI / 18);
-          ctx.shadowColor = `rgba(147, 197, 253, ${0.7 * glow})`;
+          ctx.shadowColor = `rgba(250, 204, 21, ${0.7 * glow})`;
           ctx.shadowBlur = 20 * glow;
           ctx.fillStyle = "#b45309";
           ctx.fillRect(0, -3, handleLen, 6);
           ctx.fillStyle = "#d1d5db";
           ctx.fillRect(handleLen - 2, -8, 4, 16);
-          ctx.fillStyle = `hsl(210, 100%, ${55 + 35 * glow}%)`;
+          ctx.fillStyle = "#93c5fd";
           ctx.fillRect(handleLen, -4, bladeLen, 8);
           ctx.restore();
         }


### PR DESCRIPTION
## Summary
- change sword's imminent-attack glow from blue-white to yellow
- keep sword blade color constant

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ecb9823c833283e5b2ca787cc7d9