### PR TITLE
feat: transition sword color from yellow to blue

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -3229,17 +3229,19 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           const bladeLen = swordRange - handleLen * 2;
           const glowProgress = Math.min(swordTimer / swordCooldown, 1);
           const glow = glowProgress * glowProgress;
+          const hue = 50 + (210 - 50) * glow;
+          const light = 55 + 35 * glow;
           ctx.save();
           ctx.translate(cx, cy);
           ctx.scale(player.dir, 1);
           ctx.rotate(-11 * Math.PI / 18);
-          ctx.shadowColor = `rgba(147, 197, 253, ${0.7 * glow})`;
+          ctx.shadowColor = `hsla(${hue}, 100%, ${light}%, ${0.7 * glow})`;
           ctx.shadowBlur = 20 * glow;
           ctx.fillStyle = "#b45309";
           ctx.fillRect(0, -3, handleLen, 6);
           ctx.fillStyle = "#d1d5db";
           ctx.fillRect(handleLen - 2, -8, 4, 16);
-          ctx.fillStyle = `hsl(210, 100%, ${55 + 35 * glow}%)`;
+          ctx.fillStyle = `hsl(${hue}, 100%, ${light}%)`;
           ctx.fillRect(handleLen, -4, bladeLen, 8);
           ctx.restore();
         }


### PR DESCRIPTION
## Summary
- start sword blade as yellow when idle
- gradually shift blade hue toward blue as attack cooldown completes

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c2ef0039888332a89b0d9bb90da029