### PR TITLE
fix: update HUD on game over

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -1455,6 +1455,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       }
 
       function gameOver() {
+        updateHUD(); // 즉시 HUD 업데이트
         // 죽음 애니메이션 시작
         player.deathAnim.active = true;
         player.deathAnim.time = 0;


### PR DESCRIPTION
## Summary
- update HUD immediately when game over is triggered so HP shows 0

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c380cb74588332ba6caa4cc646b4b7