### PR TITLE
Add thin outline to enemies

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -3335,6 +3335,9 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           if (!e.entered) ctx.globalAlpha = 0.5;
           ctx.fillStyle = e.color;
           ctx.fillRect(e.x, e.y, e.w, e.h);
+          ctx.strokeStyle = "#000";
+          ctx.lineWidth = 1;
+          ctx.strokeRect(e.x + 0.5, e.y + 0.5, e.w - 1, e.h - 1);
 
           // 체력 금 표시
           const dmgRatio = 1 - e.hp / e.hpMax;


### PR DESCRIPTION
## Summary
- draw 1px black stroke around enemies so overlapping enemies are distinguishable

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c39bd10ad88332a7477aa32e6c9147