### PR TITLE
Fix boss facing direction during jump pattern

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -1642,6 +1642,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           type: enemyTypes[0],
           vx: 0,
           vy: 0,
+          dir: -1,
           color: "#ff6b9d",
           damage: enemyContactDamage * enemyScale * 3,
           reward: enemyReward * 10,
@@ -1738,6 +1739,11 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       }
 
       function updateBossBehavior(b, dt) {
+        const facingPlayer =
+          player.x + player.w / 2 >= b.x + b.w / 2 ? 1 : -1;
+        if (b.attackState !== "jump" || b.jumping || b.jumpCount === 0) {
+          b.dir = facingPlayer;
+        }
         if (b.attackState === "laser") {
           b.attackCooldown -= dt * 1000;
           if (b.attackCooldown <= 0) {
@@ -1778,11 +1784,13 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
                 const targetX = player.x;
                 b.vx = (targetX - b.x) / flight;
                 b.vy = jumpVy;
+                b.dir = Math.sign(b.vx) || b.dir;
                 b.jumping = true;
                 b.jumpCount++;
               } else if (!b.returning) {
                 b.vx = (b.startX - b.x) / flight;
                 b.vy = jumpVy;
+                b.dir = Math.sign(b.vx) || b.dir;
                 b.jumping = true;
                 b.returning = true;
               } else {
@@ -3388,7 +3396,11 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           if (e.isBoss) {
             ctx.save();
             const facing =
-              player.x + player.w * 0.5 >= e.x + e.w * 0.5 ? 1 : -1;
+              e.dir !== undefined
+                ? e.dir
+                : player.x + player.w * 0.5 >= e.x + e.w * 0.5
+                ? 1
+                : -1;
             const shieldW = 5;
             const shieldH = Math.max(14, e.h * 0.9);
             const shieldY = e.y + (e.h - shieldH) / 2;


### PR DESCRIPTION
## Summary
- Track boss facing direction with `dir` and maintain it between jumps
- Use stored `dir` when rendering boss shield

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3abc84ea48332985ce54730340ea2