### PR TITLE
feat: adjust orbital orb upgrade

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -833,30 +833,33 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           icon: "🌟",
           desc: "주변을 도는 구슬이 생성됩니다.\n(처음 2개, 이후 +1개)",
           apply() {
-            if (orbitingOrbs.length >= this.limit) return;
+            const current = acquiredUpgrades[this.id] || 0;
+            const nextCount = current + 1;
 
-            // 새 구슬 추가 (최초 2개, 이후 1개)
-            const addCount = orbitingOrbs.length === 0 ? 2 : 1;
-            for (let i = 0; i < addCount && orbitingOrbs.length < this.limit; i++) {
-              orbitingOrbs.push({
-                angle: 0,
-                size: 12,
-                damage: orbitalDamage,
-                hitSet: new Set(),
-                lastAngle: 0,
+            if (orbitingOrbs.length < this.limit) {
+              // 새 구슬 추가 (최초 2개, 이후 1개)
+              const addCount = orbitingOrbs.length === 0 ? 2 : 1;
+              for (let i = 0; i < addCount && orbitingOrbs.length < this.limit; i++) {
+                orbitingOrbs.push({
+                  angle: 0,
+                  size: 12,
+                  damage: orbitalDamage,
+                  hitSet: new Set(),
+                  lastAngle: 0,
+                });
+              }
+
+              // 등간격으로 재배치
+              const count = orbitingOrbs.length;
+              const step = (Math.PI * 2) / count;
+              orbitingOrbs.forEach((orb, idx) => {
+                orb.angle = idx * step;
+                orb.lastAngle = (orb.angle + orbitalAngle) % (Math.PI * 2);
               });
             }
 
-            // 등간격으로 재배치
-            const count = orbitingOrbs.length;
-            const step = (Math.PI * 2) / count;
-            orbitingOrbs.forEach((orb, idx) => {
-              orb.angle = idx * step;
-              orb.lastAngle = (orb.angle + orbitalAngle) % (Math.PI * 2);
-            });
-
-            // 최대치에 도달하면 폭발적 강화
-            if (count === this.limit) {
+            // 업그레이드 6회 획득 시 폭발적 강화
+            if (nextCount === this.limit) {
               orbitalDamage = 500; // 궤도 구슬 피해량
               orbitalRadius = 90; // 궤도 반지름
               orbitalSpeed = 7; // 궤도 회전 속도 (rad/s)

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -3661,7 +3661,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
 
           ctx.save();
           const color =
-            orbitingOrbs.length >= UPGRADE_LIMITS.orbital
+            (acquiredUpgrades.orbital || 0) >= UPGRADE_LIMITS.orbital
               ? RAINBOW_COLORS[idx % RAINBOW_COLORS.length]
               : "#ff6b9d";
           ctx.fillStyle = color;

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -828,21 +828,24 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         },
         {
           id: "orbital",
-          limit: 7,
+          limit: 6,
           title: "궤도 구슬",
           icon: "🌟",
-          desc: "주변을 도는 구슬이 생성됩니다.\n(구슬 +1개)",
+          desc: "주변을 도는 구슬이 생성됩니다.\n(처음 2개, 이후 +1개)",
           apply() {
             if (orbitingOrbs.length >= this.limit) return;
 
-            // 새 구슬 추가
-            orbitingOrbs.push({
-              angle: 0,
-              size: 12,
-              damage: orbitalDamage,
-              hitSet: new Set(),
-              lastAngle: 0,
-            });
+            // 새 구슬 추가 (최초 2개, 이후 1개)
+            const addCount = orbitingOrbs.length === 0 ? 2 : 1;
+            for (let i = 0; i < addCount && orbitingOrbs.length < this.limit; i++) {
+              orbitingOrbs.push({
+                angle: 0,
+                size: 12,
+                damage: orbitalDamage,
+                hitSet: new Set(),
+                lastAngle: 0,
+              });
+            }
 
             // 등간격으로 재배치
             const count = orbitingOrbs.length;


### PR DESCRIPTION
## Summary
- first orbital upgrade spawns two orbs, later upgrades add one
- cap the orbital upgrade at six orbs and update description

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b1e9919c833297a10533e6c8c3fa