### PR TITLE
Hide boss shield when disabled

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -3502,7 +3502,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           }
 
           // boss는 바라보는 방향에 방패를 표시 (방패 두께 5px)
-          if (e.isBoss) {
+          if (e.isBoss && e.hasShield) {
             ctx.save();
             const facing = e.dir > 0 ? 1 : -1;
             const shieldW = 5;


### PR DESCRIPTION
## Summary
- draw boss shield only when boss has an active shield

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c79044bf688332a39b81aba3aa2a46