### PR TITLE
Disable ice floor upgrade availability

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -1044,6 +1044,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           limit: 5,
           title: "얼음 바닥",
           icon: "❄️",
+          enabled: false,
           desc: "바닥에 얼음을 생성해 적을 둔화시킵니다.\n(지속 시간 +1초, 피해 +20, 둔화 +10%)",
           apply: () => {
             const level = acquiredUpgrades["iceFloor"] || 0;
@@ -2456,6 +2457,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         // 한계 수량에 도달한 업그레이드를 제외
         const availableUpgrades = UPGRADES.filter(
           u =>
+            u.enabled !== false &&
             (!u.weapon || u.weapon === baseAttack) &&
             (acquiredUpgrades[u.id] || 0) < u.limit,
         );


### PR DESCRIPTION
## Summary
- mark the ice floor upgrade as disabled
- prevent disabled upgrades from appearing in level-up choices

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca0e32b9748332a67e7ba0d696df22