### PR TITLE
Prevent frost effect on returning yoyo hits

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -3182,7 +3182,9 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
                   e.vy = -enemyKnockbackLift;
                 }
 
-                applyFrostEffect(e);
+                if (!y.returning) {
+                  applyFrostEffect(e);
+                }
 
                 b.hitSet.add(e.id);
                 if (b.penetration === 0) {
@@ -3254,7 +3256,9 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
                   e.vy = -enemyKnockbackLift;
                 }
 
-                applyFrostEffect(e);
+                if (!y.returning) {
+                  applyFrostEffect(e);
+                }
 
                 y.hitSet.add(e.id);
 


### PR DESCRIPTION
## Summary
- guard the frost application on base yoyo hits so it only applies while traveling outward

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ca39fb49f0833283e89793a5b1214e