### PR TITLE
Ensure boss timed laser spacing respects projectile length

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -1870,6 +1870,8 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       }
 
       const BOSS_PATTERN_DELAY = 3000;
+      const BOSS_LASER_SPEED = 600; // px per second
+      const BOSS_TIMED_LASER_GAP = 200; // ms delay after a laser fully passes
 
       const BOSS_PRE_EFFECT_TIME = {
         laser: 500,
@@ -1957,7 +1959,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       function fireBossLaser(boss, opts = {}) {
         const dir =
           player.x + player.w / 2 >= boss.x + boss.w / 2 ? 1 : -1;
-        const speed = 600;
+        const speed = BOSS_LASER_SPEED;
         const width = opts.width || player.w * 3;
         const travel = ((WORLD.w + boss.w + width) / speed) * 1000;
         bossLasers.push({
@@ -2092,7 +2094,8 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
                 damage: b.attackDamage.timedLaser,
               });
               b.laserCount++;
-              b.attackCooldown = 500;
+              const travelTime = (width / BOSS_LASER_SPEED) * 1000;
+              b.attackCooldown = travelTime + BOSS_TIMED_LASER_GAP;
             } else if (!bossLasers.some((l) => l.owner === b)) {
               pickBossPattern(b);
             }


### PR DESCRIPTION
## Summary
- add constants to share boss laser speed and configure a post-laser gap
- base the timed laser cooldown on projectile width to keep spacing consistent

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb710ce8a88332929ec9a3da5488d1