### PR TITLE
Add basic sound effects for gameplay feedback

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -1199,6 +1199,25 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
               spread: 0.05,
             },
           ],
+          attackHit: [
+            {
+              wave: "sine",
+              freq: 220,
+              freqEnd: 130,
+              duration: 0.09,
+              gain: 0.15,
+              attack: 0.005,
+              release: 0.1,
+              spread: 0.04,
+            },
+            {
+              noise: true,
+              duration: 0.05,
+              gain: 0.07,
+              attack: 0.005,
+              release: 0.12,
+            },
+          ],
           hit: [
             {
               wave: "sawtooth",
@@ -2522,6 +2541,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
                 dmg = Math.max(Math.floor(dmg * e.shieldMultiplier), 1);
               }
               e.hp -= dmg;
+              audio.play("attackHit");
 
               applyFrostEffect(e);
 

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -2104,6 +2104,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           range: size,
           defense: 10,
           knockbackImmune: true,
+          entered: false,
           startX: startX,
           cracks: ((seg) =>
             Array.from({ length: seg }, (_, i) => ({

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -3423,6 +3423,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
                   dmg = Math.max(Math.floor(dmg * e.shieldMultiplier), 1);
                 }
                 e.hp -= dmg;
+                audio.play("attackHit");
 
                 if (lifeSteal > 0) {
                   const heal = Math.min(dmg * lifeSteal, playerHP - hp);
@@ -3496,6 +3497,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
                   dmg = Math.max(Math.floor(dmg * e.shieldMultiplier), 1);
                 }
                 e.hp -= dmg;
+                audio.play("attackHit");
 
                 if (lifeSteal > 0 && !y.returning) {
                   const heal = Math.min(dmg * lifeSteal, playerHP - hp);

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -1173,6 +1173,163 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       const canvas = document.getElementById("game");
       const ctx = canvas.getContext("2d");
 
+      const audio = (() => {
+        const AudioContextClass =
+          window.AudioContext || window.webkitAudioContext;
+        if (!AudioContextClass) {
+          return {
+            play: () => {},
+            resume: () => {},
+          };
+        }
+
+        const context = new AudioContextClass();
+        const masterGain = context.createGain();
+        masterGain.gain.value = 0.25;
+        masterGain.connect(context.destination);
+
+        const soundDefs = {
+          attack: [
+            {
+              wave: "square",
+              freq: 560,
+              freqEnd: 440,
+              duration: 0.12,
+              gain: 0.12,
+              spread: 0.05,
+            },
+          ],
+          hit: [
+            {
+              wave: "sawtooth",
+              freq: 220,
+              freqEnd: 120,
+              duration: 0.25,
+              gain: 0.18,
+              spread: 0.08,
+            },
+            {
+              noise: true,
+              duration: 0.18,
+              gain: 0.2,
+              release: 0.15,
+            },
+          ],
+          exp: [
+            {
+              wave: "triangle",
+              freq: 900,
+              freqEnd: 1400,
+              duration: 0.18,
+              gain: 0.12,
+              spread: 0.04,
+            },
+          ],
+          explosion: [
+            {
+              noise: true,
+              duration: 0.45,
+              gain: 0.28,
+              release: 0.3,
+            },
+            {
+              wave: "sawtooth",
+              freq: 180,
+              freqEnd: 40,
+              duration: 0.5,
+              gain: 0.16,
+              release: 0.3,
+            },
+          ],
+        };
+
+        function applyEnvelope(gainNode, start, def) {
+          const level = def.gain ?? 0.15;
+          const attack = Math.max(0.001, def.attack ?? 0.01);
+          const release = Math.max(0.01, def.release ?? 0.12);
+          const sustain = Math.max(attack, (def.duration ?? 0.2) - release);
+          const end = start + (def.duration ?? 0.2);
+          const stop = end + release;
+          gainNode.gain.cancelScheduledValues(start);
+          gainNode.gain.setValueAtTime(0.0001, start);
+          gainNode.gain.linearRampToValueAtTime(level, start + attack);
+          gainNode.gain.linearRampToValueAtTime(level, start + sustain);
+          gainNode.gain.linearRampToValueAtTime(0.0001, end);
+          gainNode.gain.linearRampToValueAtTime(0.0001, stop);
+          return stop;
+        }
+
+        function playOsc(def) {
+          const delay = def.delay ?? 0;
+          const start = context.currentTime + delay;
+          const osc = context.createOscillator();
+          osc.type = def.wave || "sine";
+          const spread = def.spread || 0;
+          const baseFreq = def.freq || 440;
+          const startFreq = baseFreq * (1 + spread * (Math.random() * 2 - 1));
+          osc.frequency.setValueAtTime(startFreq, start);
+          if (def.freqEnd && def.freqEnd !== startFreq) {
+            osc.frequency.linearRampToValueAtTime(
+              def.freqEnd,
+              start + (def.duration ?? 0.2),
+            );
+          }
+          const gainNode = context.createGain();
+          const stop = applyEnvelope(gainNode, start, def);
+          osc.connect(gainNode);
+          gainNode.connect(masterGain);
+          osc.start(start);
+          osc.stop(stop + 0.01);
+        }
+
+        function playNoise(def) {
+          const delay = def.delay ?? 0;
+          const start = context.currentTime + delay;
+          const total = (def.duration ?? 0.2) + (def.release ?? 0.12);
+          const length = Math.max(1, Math.floor(context.sampleRate * total));
+          const buffer = context.createBuffer(1, length, context.sampleRate);
+          const data = buffer.getChannelData(0);
+          for (let i = 0; i < length; i++) {
+            const fade = 1 - i / length;
+            data[i] = (Math.random() * 2 - 1) * fade;
+          }
+          const source = context.createBufferSource();
+          source.buffer = buffer;
+          const gainNode = context.createGain();
+          const stop = applyEnvelope(gainNode, start, def);
+          source.connect(gainNode);
+          gainNode.connect(masterGain);
+          source.start(start);
+          source.stop(stop + 0.01);
+        }
+
+        function play(name) {
+          const def = soundDefs[name];
+          if (!def) return;
+          if (context.state === "suspended") {
+            context.resume().catch(() => {});
+          }
+          const parts = Array.isArray(def) ? def : [def];
+          for (const part of parts) {
+            if (part.noise) playNoise(part);
+            else playOsc(part);
+          }
+        }
+
+        function resume() {
+          if (context.state === "suspended") {
+            context.resume().catch(() => {});
+          }
+        }
+
+        const unlock = () => resume();
+        window.addEventListener("pointerdown", unlock, { once: true });
+        window.addEventListener("keydown", unlock, { once: true });
+        window.addEventListener("touchstart", unlock, { once: true });
+
+        return { play, resume };
+      })();
+
       // --- 게임 상태 ---
       let running = false;
       let paused = false; // 레벨업/ESC 일시정지
@@ -1685,6 +1842,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       }
 
       function startGame(attack = "gun") {
+        audio.resume();
         baseAttack = attack;
         reset();
         overlay.style.display = "none";
@@ -2208,6 +2366,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           duration: 200,
           color: "#f97316",
         });
+        audio.play("explosion");
         let base = explosionMinDamage;
         if (playerDist > 20) base += (playerDist - 20) * INIT.EXPLOSION.DAMAGE_STEP;
         let primaryExtra = 0;
@@ -2342,6 +2501,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           holdLife: 0,
           range: swordRange,
         });
+        audio.play("attack");
         let totalHeal = 0;
         const missingHP = playerHP - hp;
         for (let i = enemies.length - 1; i >= 0; i--) {
@@ -2681,6 +2841,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         </div>`;
         overlay.style.display = "flex";
         document.getElementById("btnStart").onclick = () => {
+          audio.resume();
           overlay.style.display = "none";
           showWeaponSelectScreen();
         };
@@ -2698,6 +2859,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         </div>`;
         overlay.style.display = "flex";
         document.getElementById("btnRestart").onclick = () => {
+          audio.resume();
           overlay.style.display = "none";
           showWeaponSelectScreen();
         };
@@ -2817,6 +2979,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             hitSet: new Set(),
             range: bulletRange,
           });
+          audio.play("attack");
         }
         if (baseAttack === "yoyo" && yoyos.length === 0) {
           const yx = player.dir > 0 ? player.x + player.w : player.x - yoyoSize;
@@ -2832,6 +2995,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             travel: 0,
             hitSet: new Set(),
           });
+          audio.play("attack");
         }
 
         // 레이저 구슬 발사
@@ -2968,6 +3132,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
               const finalDamage = Math.max(raw, 1);
               const dmg = Math.min(finalDamage, hp);
               hp -= dmg;
+              audio.play("hit");
               spawnFloatText(
                 player.x + player.w / 2,
                 player.y - 14,
@@ -3062,6 +3227,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
               exp += orb.value;
               checkLevelUp();
             }
+            audio.play("exp");
             continue;
           }
 
@@ -3447,6 +3613,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
                 const finalDamage = Math.max(raw, 1);
                 const dmg = Math.min(finalDamage, hp);
                 hp -= dmg;
+                audio.play("hit");
                 spawnFloatText(
                   player.x + player.w / 2,
                   player.y - 14,


### PR DESCRIPTION
## Summary
- add a lightweight Web Audio manager that synthesizes attack, hit, experience, and explosion cues and unlocks audio on the first interaction
- trigger the new sound cues during attacks, explosions, experience pickup, player damage, and when starting or restarting the game

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc10797b9883329ff8a41ba1535867