### PR TITLE
Add boss death sound effect

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -1260,6 +1260,36 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
               release: 0.3,
             },
           ],
+          bossDeath: [
+            {
+              wave: "sawtooth",
+              freq: 140,
+              freqEnd: 50,
+              duration: 0.6,
+              gain: 0.22,
+              attack: 0.01,
+              release: 0.45,
+              spread: 0.02,
+            },
+            {
+              noise: true,
+              duration: 0.5,
+              gain: 0.24,
+              attack: 0.02,
+              release: 0.5,
+            },
+            {
+              wave: "triangle",
+              freq: 360,
+              freqEnd: 160,
+              duration: 0.45,
+              gain: 0.14,
+              attack: 0.015,
+              release: 0.35,
+              delay: 0.05,
+              spread: 0.04,
+            },
+          ],
         };
 
         function applyEnvelope(gainNode, start, def) {
@@ -2366,6 +2396,10 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           spawnExpOrb(x, y);
         }
         if (e.isBoss) {
+          if (!e._bossDeathSoundPlayed) {
+            audio.play("bossDeath");
+            e._bossDeathSoundPlayed = true;
+          }
           if (e._bigOrbDropped) return;
           e._bigOrbDropped = true;
           spawnExpOrb(x, y, {


### PR DESCRIPTION
## Summary
- add a layered "boss death" sound to the synth sound definitions
- trigger the boss death sound the first time a defeated boss drops rewards

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc2a9537b883329aad1012c017e194