### PR TITLE
Limit sword hit and explosion sounds to one per swing

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -2433,7 +2433,13 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         }
       }
 
-      function triggerExplosion(cx, cy, playerDist, primaryId = null) {
+      function triggerExplosion(
+        cx,
+        cy,
+        playerDist,
+        primaryId = null,
+        playSound = true,
+      ) {
         impulseEffects.push({
           x: cx,
           y: cy,
@@ -2442,7 +2448,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           duration: 200,
           color: "#f97316",
         });
-        audio.play("explosion");
+        if (playSound) audio.play("explosion");
         let base = explosionMinDamage;
         if (playerDist > 20) base += (playerDist - 20) * INIT.EXPLOSION.DAMAGE_STEP;
         let primaryExtra = 0;
@@ -2581,6 +2587,8 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         audio.play("attack");
         let totalHeal = 0;
         const missingHP = playerHP - hp;
+        let hitSoundPlayed = false;
+        let explosionSoundPlayed = false;
         for (let i = enemies.length - 1; i >= 0; i--) {
           const e = enemies[i];
           if (!e.entered) continue;
@@ -2599,13 +2607,23 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
                 dmg = Math.max(Math.floor(dmg * e.shieldMultiplier), 1);
               }
               e.hp -= dmg;
-              audio.play("attackHit");
+              if (!hitSoundPlayed) {
+                audio.play("attackHit");
+                hitSoundPlayed = true;
+              }
 
               applyFrostEffect(e);
 
               let extra = 0;
               if (explosionEnabled) {
-                extra = triggerExplosion(ex, ey, distToPlayer, e.id);
+                extra = triggerExplosion(
+                  ex,
+                  ey,
+                  distToPlayer,
+                  e.id,
+                  !explosionSoundPlayed,
+                );
+                explosionSoundPlayed = true;
                 if (i >= enemies.length || enemies[i].id !== e.id) {
                   spawnFloatText(ex, e.y - 12, -(dmg + extra), "#ff6b6b");
                   continue;


### PR DESCRIPTION
## Summary
- ensure the sword attack only plays its hit sound once per swing even when multiple enemies are struck
- allow sword-triggered explosions to play their sound a single time per swing via an optional trigger parameter

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc311c3c5c8332992e8b62fb8a8633