### PR TITLE
Give sword base knockback upgrade

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -1997,6 +1997,15 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         swordEnabled = baseAttack === "sword";
 
         for (const id in acquiredUpgrades) delete acquiredUpgrades[id];
+
+        if (baseAttack === "sword") {
+          const knockbackUpgrade = UPGRADES.find(u => u.id === "knockback");
+          if (knockbackUpgrade) {
+            knockbackUpgrade.apply();
+            acquiredUpgrades[knockbackUpgrade.id] = 1;
+          }
+        }
+
         updateUpgradeHUD();
 
         updateHUD();


### PR DESCRIPTION
## Summary
- automatically grant sword loadouts a knockback upgrade during reset

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ccb3bc4ffc8332ba8b46d2de7816ba