### PR TITLE
Adjust yoyo damage scaling

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -617,10 +617,12 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         // 요요 관련
         YOYO: {
           SIZE: 12, // 요요 크기
-          DAMAGE: 80, // 요요 피해량
+          DAMAGE: 50, // 요요 피해량
           RANGE: 140, // 요요 사정거리 (px)
           KNOCKBACK: 0, // 요요 넉백 거리 (px)
           SPEED: 250, // 요요 던지는 속도 (px/s)
+          MINIMUM_DAMAGE_RANGE: 40, // 최소 데미지 범위
+          MAG_PER_DIST: 0.01, // 거리당 데미지 배율
           DAMAGE_STEP: 0.2, // 공격력 업그레이드당 피해 증가율 (20%)
           RANGE_STEP: 0.2, // 사거리 업그레이드당 증가율 (20%)
           KNOCKBACK_STEP: 40, // 넉백 업그레이드당 거리 증가량 (px)
@@ -3661,7 +3663,20 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
               if (aabb(e, y)) {
                 const ex = e.x + e.w / 2;
                 const ey = e.y + e.h / 2;
-                const raw = y.dmg - (e.defense || 0);
+                const px = player.x + player.w / 2;
+                const py = player.y + player.h / 2;
+                const distanceToPlayer = Math.hypot(ex - px, ey - py);
+                const damageDistance = Math.min(
+                  distanceToPlayer - INIT.YOYO.MINIMUM_DAMAGE_RANGE,
+                  0,
+                );
+                const baseDamage = y.dmg;
+                const scaledDamage = Math.max(
+                  baseDamage *
+                    (1 + damageDistance * INIT.YOYO.MAG_PER_DIST),
+                  0,
+                );
+                const raw = scaledDamage - (e.defense || 0);
                 let dmg = Math.min(Math.max(raw, 1), e.hp);
                 if (
                   e.isBoss &&


### PR DESCRIPTION
## Summary
- reduce the base yoyo damage and introduce tuning constants for distance-based scaling
- apply distance-based scaling when the yoyo hits enemies so damage increases with separation from the player

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ccc4e1046c8332862171aec18ec025