### PR TITLE
Stop explosion upgrade damaging primary enemy

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -2839,6 +2839,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         let base = explosionMinDamage;
         if (playerDist > 20) base += (playerDist - 20) * INIT.EXPLOSION.DAMAGE_STEP;
         let primaryExtra = 0;
+        const skipId = primaryId ?? null;
         for (let i = enemies.length - 1; i >= 0; i--) {
           const e = enemies[i];
           if (!e.entered) continue;
@@ -2846,17 +2847,17 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           const ey = e.y + e.h / 2;
           const dist = Math.hypot(ex - cx, ey - cy);
           if (dist <= explosionRadius) {
+            if (skipId !== null && e.id === skipId) {
+              // 적이 자신의 폭발 효과로 추가 피해를 받지 않도록 제외
+              continue;
+            }
             const raw = base - (e.defense || 0);
             let dmg = Math.min(Math.max(raw, 1), e.hp);
             if (e.isBoss && e.hasShield && isBossFacingPlayer(e)) {
               dmg = Math.max(Math.floor(dmg * e.shieldMultiplier), 1);
             }
             e.hp -= dmg;
-            if (e.id === primaryId) {
-              primaryExtra = dmg;
-            } else {
-              spawnFloatText(e.x + e.w / 2, e.y - 12, -dmg, "#ff6b6b");
-            }
+            spawnFloatText(e.x + e.w / 2, e.y - 12, -dmg, "#ff6b6b");
             if (e.hp <= 0) {
               dropExpOrbs(e);
               enemies.splice(i, 1);


### PR DESCRIPTION
## Summary
- prevent the explosion upgrade from applying extra damage to the enemy that triggered it
- skip the primary target while iterating explosion damage so only nearby foes are hit

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ce40d612a483329a7b9e1ae12b5df2