### PR TITLE
Adjust health upgrade behavior and level-up options

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -597,7 +597,6 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           IFRAMES: 500, // 피격 후 무적 시간 (ms)
           HITFLASH: 200, // 피격 시 시각 효과 지속 시간 (ms)
           DEFENSE: 0, // 플레이어 방어력
-          HP_STEP: 500, // 체력 증가 업그레이드당 최대 HP 증가량
           LEVEL_HP_STEP: 100, // 레벨업 시 증가할 최대 HP
           DEFENSE_STEP: 50, // 방어력 업그레이드당 증가량
           DEFENSE_REFLECT_MULT: 2, // 방어로 반사되는 피해 배수
@@ -1081,12 +1080,11 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         },
         {
           id: "health",
-          limit: 10,
-          title: "체력 증가",
+          limit: Infinity,
+          title: "체력 회복",
           icon: "❤️",
-          desc: "최대 체력이 증가하고 체력을 모두 회복합니다.\n(+500)",
+          desc: "체력을 모두 회복합니다.",
           apply: () => {
-            playerHP += INIT.PLAYER.HP_STEP;
             const healed = playerHP - hp;
             hp = playerHP;
             if (healed > 0)
@@ -3369,12 +3367,20 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             (acquiredUpgrades[u.id] || 0) < u.limit,
         );
 
+        const healthUpgrade = availableUpgrades.find((u) => u.id === "health");
+        const otherUpgrades = availableUpgrades.filter((u) => u.id !== "health");
+
         let selected;
         if (all) {
-          selected = availableUpgrades;
+          selected = [];
+          if (healthUpgrade) selected.push(healthUpgrade);
+          selected.push(...otherUpgrades);
         } else {
-          const shuffled = [...availableUpgrades].sort(() => Math.random() - 0.5);
-          selected = shuffled.slice(0, 3);
+          const shuffled = [...otherUpgrades].sort(() => Math.random() - 0.5);
+          selected = [
+            ...(healthUpgrade ? [healthUpgrade] : []),
+            ...shuffled.slice(0, 3),
+          ];
         }
 
         upgradeGrid.innerHTML = "";
@@ -3382,8 +3388,9 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           const btn = document.createElement("div");
           btn.className = "upgrade-btn";
           const current = acquiredUpgrades[upgrade.id] || 0;
+          const limitText = Number.isFinite(upgrade.limit) ? upgrade.limit : "∞";
           btn.innerHTML = `
-            <div class="upgrade-title">${upgrade.icon} ${upgrade.title} (${current}/${upgrade.limit})</div>
+            <div class="upgrade-title">${upgrade.icon} ${upgrade.title} (${current}/${limitText})</div>
             <div class="upgrade-desc">${upgrade.desc}</div>
         `;
           btn.onclick = () => {


### PR DESCRIPTION
## Summary
- rename the health upgrade to 체력 회복, remove the max HP increase, and keep the full-heal effect available indefinitely
- expand normal level-up choices to four entries with 체력 회복 always listed first and show ∞ when an upgrade has no limit

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d01406a1a88332ae8a0d5b67465786