### PR TITLE
Fix boss removal when yo-yo explosions hit

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -3212,7 +3212,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
                   !explosionSoundPlayed,
                 );
                 explosionSoundPlayed = true;
-                if (i >= enemies.length || enemies[i].id !== e.id) {
+                if (!enemies.includes(e)) {
                   spawnFloatText(ex, e.y - 12, -(dmg + extra), "#ff6b6b");
                   continue;
                 }
@@ -4237,7 +4237,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
                   extra = triggerExplosion(ex, ey, distP, e.id);
                 }
                 spawnFloatText(ex, e.y - 12, -(dmg + extra), "#ff6b6b");
-                if (explosionEnabled && (i >= enemies.length || enemies[i].id !== e.id)) {
+                if (explosionEnabled && !enemies.includes(e)) {
                   e._killed = true;
                   break;
                 }
@@ -4320,7 +4320,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
                   extra = triggerExplosion(ex, ey, distP, e.id);
                 }
                 spawnFloatText(ex, e.y - 12, -(dmg + extra), "#ff6b6b");
-                if (explosionEnabled && !y.returning && (i >= enemies.length || enemies[i].id !== e.id)) {
+                if (explosionEnabled && !y.returning && !enemies.includes(e)) {
                   e._killed = true;
                   break;
                 }


### PR DESCRIPTION
## Summary
- fix the explosion clean-up logic so it checks whether the damaged enemy still exists
- prevent yo-yo-triggered explosions from incorrectly flagging the boss as killed

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d15f7512ac8332b17f2fcff93532f6