### PR TITLE
Disable double upgrades for boss rewards

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -3449,7 +3449,8 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           const remaining = Math.max(0, limitValue - current);
           const canDouble =
             option.id !== "health" &&
-            remaining >= 2;
+            remaining >= 2 &&
+            !all;
           option.isDouble = false;
           if (canDouble && Math.random() < 0.1) {
             option.isDouble = true;


### PR DESCRIPTION
## Summary
- ensure boss or cheat-triggered upgrade selections no longer roll the random double-upgrade option

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d163a994f88332bd61fccd4ee3861e