### PR TITLE
Add leaderboard submission after game over

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -122,6 +122,60 @@
       color: #cfd6ff;
     }
 
+    .leaderboard-form {
+      margin-top: calc(18px * var(--ui-scale));
+      display: flex;
+      flex-direction: column;
+      gap: calc(10px * var(--ui-scale));
+      align-items: stretch;
+      text-align: left;
+    }
+
+    .leaderboard-form label {
+      display: flex;
+      flex-direction: column;
+      gap: calc(6px * var(--ui-scale));
+      font-weight: 600;
+      color: #cfd6ff;
+    }
+
+    .leaderboard-form input {
+      padding: calc(10px * var(--ui-scale)) calc(12px * var(--ui-scale));
+      border-radius: calc(10px * var(--ui-scale));
+      border: 1px solid #2b356e;
+      background: #0e1330;
+      color: #fff;
+      font-size: inherit;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      outline: none;
+    }
+
+    .leaderboard-form input::placeholder {
+      color: #4a5286;
+      font-weight: 500;
+    }
+
+    .leaderboard-form button {
+      align-self: center;
+    }
+
+    .leaderboard-status {
+      min-height: calc(18px * var(--ui-scale));
+      font-size: calc(12px * var(--ui-scale));
+      color: #cfd6ff;
+      text-align: center;
+    }
+
+    .leaderboard-status.success {
+      color: #8fffd1;
+    }
+
+    .leaderboard-status.error {
+      color: #ff9c9c;
+    }
+
     .kbd {
       background: #0e1330;
       border: 1px solid #2b356e;
@@ -633,6 +687,9 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       // ========================================
       // 게임 밸런스 변수 (수정 편의성을 위해 상단 집중 배치)
       // ========================================
+
+      const APPS_SCRIPT_URL = ""; // 배포된 앱스 스크립트 웹 앱 URL을 여기에 입력하세요
+      const LEADERBOARD_NAME_LENGTH = 3;
 
       // 게임 초기 상수 값들 (변경이 필요한 경우 여기서만 수정하면 됩니다)
       const INIT = {
@@ -2035,6 +2092,16 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         if (running) toggleDirection();
       });
       window.addEventListener("keydown", (e) => {
+        const target = e.target;
+        if (
+          target instanceof HTMLElement &&
+          (target.tagName === "INPUT" ||
+            target.tagName === "TEXTAREA" ||
+            target.isContentEditable)
+        ) {
+          if (e.code === "Escape") target.blur();
+          return;
+        }
         if (e.code === "Space") {
           e.preventDefault();
           if (levelupActive) {
@@ -2097,6 +2164,15 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         }
       });
       window.addEventListener("keyup", (e) => {
+        const target = e.target;
+        if (
+          target instanceof HTMLElement &&
+          (target.tagName === "INPUT" ||
+            target.tagName === "TEXTAREA" ||
+            target.isContentEditable)
+        ) {
+          return;
+        }
         if (e.code === "Space") {
           if (levelupActive) {
             e.preventDefault();
@@ -2214,6 +2290,11 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       const overlay = document.getElementById("overlay");
       const pauseButton = document.getElementById("pauseButton");
       const muteButton = document.getElementById("muteButton");
+
+      const versionLabelEl = document.querySelector(".version-label");
+      const GAME_VERSION = versionLabelEl
+        ? versionLabelEl.textContent.trim()
+        : "";
 
       const tipElem = document.getElementById("tip");
       const tips = [
@@ -2468,12 +2549,17 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         setTimeout(() => {
           running = false;
           updatePauseButton();
+          const minutes = Math.floor(elapsed / 60);
+          const secondsLabel = (elapsed % 60).toFixed(2).padStart(5, "0");
+          const upgradeSnapshot = { ...acquiredUpgrades };
           showGameOverScreen({
             wave: getWaveLabel(),
-            time: `${Math.floor(elapsed / 60)}분 ${(elapsed % 60).toFixed(2).padStart(5, "0")}초`,
+            time: `${minutes}분 ${secondsLabel}초`,
             score,
             weapon: baseAttack,
             level,
+            elapsedSeconds: elapsed,
+            upgrades: upgradeSnapshot,
           });
         }, 1000);
       }
@@ -3640,9 +3726,98 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           <p>처치 수: <b>${stats.score}</b></p>
           <p>사용 무기: <b>${weaponLabel}</b></p>
           <p>최종 레벨: <b>${levelLabel}</b></p>
+          <form id="leaderboardForm" class="leaderboard-form" autocomplete="off">
+            <label for="nicknameInput">닉네임 (영문 ${LEADERBOARD_NAME_LENGTH}글자)
+              <input
+                id="nicknameInput"
+                name="nickname"
+                type="text"
+                inputmode="latin"
+                autocapitalize="characters"
+                spellcheck="false"
+                maxlength="${LEADERBOARD_NAME_LENGTH}"
+                pattern="[A-Za-z]{${LEADERBOARD_NAME_LENGTH}}"
+                placeholder="AAA"
+                required
+              />
+            </label>
+            <button type="submit" id="submitScoreButton">리더보드 전송</button>
+            <div id="leaderboardStatus" class="leaderboard-status" aria-live="polite"></div>
+          </form>
           <div class="row"><button id="btnRestart">다시 하기<br>(SPACE)</button></div>
         </div>`;
         overlay.style.display = "flex";
+        const leaderboardForm = document.getElementById("leaderboardForm");
+        const nicknameInput = document.getElementById("nicknameInput");
+        const submitScoreButton = document.getElementById("submitScoreButton");
+        const leaderboardStatus = document.getElementById("leaderboardStatus");
+        let leaderboardSubmitted = false;
+        let leaderboardSubmitting = false;
+
+        if (
+          leaderboardForm &&
+          nicknameInput &&
+          submitScoreButton &&
+          leaderboardStatus
+        ) {
+          nicknameInput.addEventListener("input", () => {
+            const sanitized = sanitizeLeaderboardName(nicknameInput.value);
+            if (nicknameInput.value !== sanitized) nicknameInput.value = sanitized;
+          });
+
+          leaderboardForm.addEventListener("submit", async (event) => {
+            event.preventDefault();
+            if (leaderboardSubmitting || leaderboardSubmitted) return;
+
+            const nickname = sanitizeLeaderboardName(nicknameInput.value);
+            if (nickname.length !== LEADERBOARD_NAME_LENGTH) {
+              leaderboardStatus.textContent = `닉네임은 영문 ${LEADERBOARD_NAME_LENGTH}글자로 입력해주세요.`;
+              leaderboardStatus.className = "leaderboard-status error";
+              nicknameInput.focus();
+              return;
+            }
+
+            const rawElapsed = Number(stats.elapsedSeconds ?? 0);
+            const elapsedSeconds = Number.isFinite(rawElapsed) ? rawElapsed : 0;
+            const payload = {
+              name: nickname,
+              wave: stats.wave ?? null,
+              weapon: stats.weapon ?? "",
+              score: stats.score ?? 0,
+              time: Number(elapsedSeconds.toFixed(2)),
+              level: stats.level ?? null,
+              upgrades: stats.upgrades ?? {},
+              version: stats.version || GAME_VERSION,
+            };
+
+            try {
+              leaderboardSubmitting = true;
+              submitScoreButton.disabled = true;
+              nicknameInput.disabled = true;
+              leaderboardStatus.textContent = "전송 중...";
+              leaderboardStatus.className = "leaderboard-status";
+              await submitLeaderboardScore(payload);
+              leaderboardSubmitted = true;
+              leaderboardStatus.textContent = "리더보드 전송 완료!";
+              leaderboardStatus.className = "leaderboard-status success";
+            } catch (error) {
+              console.error("리더보드 전송 실패:", error);
+              const message = APPS_SCRIPT_URL
+                ? "전송에 실패했습니다. 잠시 후 다시 시도해주세요."
+                : "리더보드 URL이 설정되지 않았습니다.";
+              leaderboardStatus.textContent = message;
+              leaderboardStatus.className = "leaderboard-status error";
+              submitScoreButton.disabled = false;
+              nicknameInput.disabled = false;
+            } finally {
+              leaderboardSubmitting = false;
+            }
+          });
+
+          requestAnimationFrame(() => {
+            nicknameInput.focus();
+          });
+        }
         const btnRestart = document.getElementById("btnRestart");
         btnRestart.onclick = () => {
           audio.resume();
@@ -3652,6 +3827,33 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         };
         btnRestart.addEventListener("mouseenter", () => {
           audio.play("uiFocus");
+        });
+      }
+
+      function sanitizeLeaderboardName(value) {
+        return (value || "")
+          .toUpperCase()
+          .replace(/[^A-Z]/g, "")
+          .slice(0, LEADERBOARD_NAME_LENGTH);
+      }
+
+      async function submitLeaderboardScore(payload) {
+        if (!APPS_SCRIPT_URL || !APPS_SCRIPT_URL.trim()) {
+          throw new Error("Apps Script URL is not configured.");
+        }
+
+        const body = JSON.stringify({
+          ...payload,
+          upgrades: payload.upgrades ?? {},
+        });
+
+        await fetch(APPS_SCRIPT_URL, {
+          method: "POST",
+          mode: "no-cors",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body,
         });
       }
 

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -210,6 +210,12 @@
       filter: brightness(1.05);
     }
 
+    button.focused {
+      outline: calc(3px * var(--ui-scale)) solid rgba(255, 255, 255, 0.85);
+      outline-offset: calc(2px * var(--ui-scale));
+      box-shadow: 0 0 calc(16px * var(--ui-scale)) rgba(120, 158, 255, 0.45);
+    }
+
     .hud {
       position: absolute;
       left: calc(12px * var(--ui-scale));
@@ -1922,6 +1928,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       let holdGaugeRAF = null;
       let holdGaugeFill = null;
       let selectionButtons = [];
+      let holdSelectionActive = false;
       let spaceLocked = false;
 
       function updatePauseButton() {
@@ -2094,18 +2101,18 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       });
       window.addEventListener("keydown", (e) => {
         const target = e.target;
-        if (
+        const isTextField =
           target instanceof HTMLElement &&
           (target.tagName === "INPUT" ||
             target.tagName === "TEXTAREA" ||
-            target.isContentEditable)
-        ) {
+            target.isContentEditable);
+        if (isTextField) {
           if (e.code === "Escape") target.blur();
-          return;
+          if (e.code !== "Space") return;
         }
         if (e.code === "Space") {
           e.preventDefault();
-          if (levelupActive) {
+          if (holdSelectionActive) {
             if (spaceHoldStart === null) {
               spaceLocked = true;
               startHold();
@@ -2166,16 +2173,16 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       });
       window.addEventListener("keyup", (e) => {
         const target = e.target;
-        if (
+        const isTextField =
           target instanceof HTMLElement &&
           (target.tagName === "INPUT" ||
             target.tagName === "TEXTAREA" ||
-            target.isContentEditable)
-        ) {
+            target.isContentEditable);
+        if (isTextField && e.code !== "Space") {
           return;
         }
         if (e.code === "Space") {
-          if (levelupActive) {
+          if (holdSelectionActive) {
             e.preventDefault();
             if (spaceHoldStart !== null) endHold(true);
           }
@@ -2396,6 +2403,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         running = false;
         paused = false;
         levelupActive = false;
+        clearHoldSelection();
         audio.setAttackMelody(baseAttack);
         updatePauseButton();
         lastTime = performance.now();
@@ -3444,25 +3452,47 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
 
       function highlightFocusedOption() {
         selectionButtons.forEach((btn, idx) => {
-          btn.classList.toggle("focused", idx === focusedOptionIndex);
+          if (btn && btn.classList) {
+            btn.classList.toggle("focused", idx === focusedOptionIndex);
+          }
         });
+      }
+
+      function isElementDisabled(element) {
+        if (!element) return true;
+        if ("disabled" in element && element.disabled) return true;
+        return (
+          typeof element.getAttribute === "function" &&
+          element.getAttribute("aria-disabled") === "true"
+        );
       }
 
       function moveFocus(delta) {
         if (!selectionButtons.length) return;
         const previousIndex = focusedOptionIndex;
-        focusedOptionIndex =
-          (focusedOptionIndex + delta + selectionButtons.length) % selectionButtons.length;
+        const total = selectionButtons.length;
+        let newIndex = focusedOptionIndex;
+        let found = false;
+        for (let i = 0; i < total; i++) {
+          newIndex = (newIndex + delta + total) % total;
+          if (!isElementDisabled(selectionButtons[newIndex])) {
+            found = true;
+            break;
+          }
+        }
+        if (found) {
+          focusedOptionIndex = newIndex;
+        }
         highlightFocusedOption();
-        if (focusedOptionIndex !== previousIndex) {
+        if (found && focusedOptionIndex !== previousIndex) {
           audio.play("uiFocus");
         }
       }
 
       function selectCurrentOption() {
-        if (selectionButtons[focusedOptionIndex]) {
-          selectionButtons[focusedOptionIndex].click();
-        }
+        const current = selectionButtons[focusedOptionIndex];
+        if (!current || isElementDisabled(current)) return;
+        current.click();
       }
 
       function updateHoldGauge() {
@@ -3471,7 +3501,9 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           (performance.now() - spaceHoldStart) / HOLD_DURATION,
           1,
         );
-        holdGaugeFill.style.width = `${progress * 100}%`;
+        if (holdGaugeFill) {
+          holdGaugeFill.style.width = `${progress * 100}%`;
+        }
         if (progress < 1) {
           holdGaugeRAF = requestAnimationFrame(updateHoldGauge);
         }
@@ -3493,9 +3525,52 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         holdTimeout = null;
         cancelAnimationFrame(holdGaugeRAF);
         holdGaugeRAF = null;
-        holdGaugeFill.style.width = "0%";
+        if (holdGaugeFill) {
+          holdGaugeFill.style.width = "0%";
+        }
         spaceHoldStart = null;
         if (moveNext) moveFocus(1);
+      }
+
+      function configureHoldSelection(buttons, gaugeElement, initialIndex = 0) {
+        const elements = Array.from(buttons || []).filter((btn) =>
+          btn instanceof HTMLElement,
+        );
+        selectionButtons = elements;
+        holdGaugeFill =
+          gaugeElement instanceof HTMLElement ? gaugeElement : null;
+        if (!selectionButtons.length) {
+          holdSelectionActive = false;
+          focusedOptionIndex = 0;
+          if (holdGaugeFill) {
+            holdGaugeFill.style.width = "0%";
+          }
+          return;
+        }
+        holdSelectionActive = true;
+        focusedOptionIndex = Math.min(
+          Math.max(initialIndex, 0),
+          selectionButtons.length - 1,
+        );
+        if (holdGaugeFill) {
+          holdGaugeFill.style.width = "0%";
+        }
+        highlightFocusedOption();
+      }
+
+      function clearHoldSelection() {
+        if (spaceHoldStart !== null) {
+          endHold(false);
+        }
+        holdSelectionActive = false;
+        selectionButtons.forEach((btn) => {
+          if (btn && btn.classList) {
+            btn.classList.remove("focused");
+          }
+        });
+        selectionButtons = [];
+        focusedOptionIndex = 0;
+        holdGaugeFill = null;
       }
 
       function showLevelUpScreen(remainingLevels, all = false) {
@@ -3586,6 +3661,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             }
             levelupOverlay.style.display = "none";
             levelupActive = false;
+            clearHoldSelection();
             updatePauseButton();
 
             // 남은 레벨업이 있으면 다음 레벨업 화면 표시
@@ -3622,11 +3698,10 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         }
         levelupOverlay.style.display = "flex";
         audio.play("upgradeOpen");
-        selectionButtons = document.querySelectorAll("#upgradeGrid .upgrade-btn");
-        focusedOptionIndex = 0;
-        holdGaugeFill = document.getElementById("holdGaugeFill");
-        highlightFocusedOption();
-        holdGaugeFill.style.width = "0%";
+        configureHoldSelection(
+          document.querySelectorAll("#upgradeGrid .upgrade-btn"),
+          document.getElementById("holdGaugeFill"),
+        );
         levelupActive = true;
         updatePauseButton();
       }
@@ -3659,6 +3734,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             audio.play("uiSelect");
             weaponOverlay.style.display = "none";
             levelupActive = false;
+            clearHoldSelection();
             updatePauseButton();
             startGame(w.id);
           };
@@ -3672,16 +3748,16 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           weaponGrid.appendChild(btn);
         });
         weaponOverlay.style.display = "flex";
-        selectionButtons = document.querySelectorAll("#weaponGrid .upgrade-btn");
-        focusedOptionIndex = 0;
-        holdGaugeFill = document.getElementById("weaponHoldGaugeFill");
-        highlightFocusedOption();
-        holdGaugeFill.style.width = "0%";
+        configureHoldSelection(
+          document.querySelectorAll("#weaponGrid .upgrade-btn"),
+          document.getElementById("weaponHoldGaugeFill"),
+        );
         levelupActive = true;
         updatePauseButton();
       }
 
       function showStartScreen() {
+        clearHoldSelection();
         updatePauseButton();
         overlay.innerHTML = `
         <div class="panel">
@@ -3713,6 +3789,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       }
 
       function showGameOverScreen(stats) {
+        clearHoldSelection();
         updatePauseButton();
         const { icon, name } = getWeaponDisplay(stats.weapon);
         const weaponLabel = `${icon ? `${icon} ` : ""}${name}`.trim();
@@ -3728,6 +3805,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           <p>처치 수: <b>${stats.score}</b></p>
           <p>사용 무기: <b>${weaponLabel}</b></p>
           <p>최종 레벨: <b>${levelLabel}</b></p>
+          <div class="row"><button id="btnRestart">다시 하기<br>(SPACE)</button></div>
           <form id="leaderboardForm" class="leaderboard-form" autocomplete="off">
             <label for="nicknameInput">닉네임 (영문 ${LEADERBOARD_NAME_LENGTH}글자)
               <input
@@ -3746,13 +3824,17 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             <button type="submit" id="submitScoreButton">리더보드 전송</button>
             <div id="leaderboardStatus" class="leaderboard-status" aria-live="polite"></div>
           </form>
-          <div class="row"><button id="btnRestart">다시 하기<br>(SPACE)</button></div>
+          <div class="hold-gauge"><div class="fill" id="gameOverHoldGaugeFill"></div></div>
         </div>`;
         overlay.style.display = "flex";
+        const btnRestart = document.getElementById("btnRestart");
         const leaderboardForm = document.getElementById("leaderboardForm");
         const nicknameInput = document.getElementById("nicknameInput");
         const submitScoreButton = document.getElementById("submitScoreButton");
         const leaderboardStatus = document.getElementById("leaderboardStatus");
+        const gameOverHoldGaugeFill = document.getElementById(
+          "gameOverHoldGaugeFill",
+        );
         let leaderboardSubmitted = false;
         let leaderboardSubmitting = false;
 
@@ -3819,6 +3901,11 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
               leaderboardSubmitted = true;
               leaderboardStatus.textContent = "리더보드 전송 완료!";
               leaderboardStatus.className = "leaderboard-status success";
+              const restartIndex = selectionButtons.indexOf(btnRestart);
+              if (restartIndex !== -1) {
+                focusedOptionIndex = restartIndex;
+                highlightFocusedOption();
+              }
             } catch (error) {
               console.error("리더보드 전송 실패:", error);
               const message = APPS_SCRIPT_URL
@@ -3828,6 +3915,11 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
               leaderboardStatus.className = "leaderboard-status error";
               submitScoreButton.disabled = false;
               nicknameInput.disabled = false;
+              const submitIndex = selectionButtons.indexOf(submitScoreButton);
+              if (submitIndex !== -1) {
+                focusedOptionIndex = submitIndex;
+                highlightFocusedOption();
+              }
             } finally {
               leaderboardSubmitting = false;
             }
@@ -3837,16 +3929,36 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             nicknameInput.focus();
           });
         }
-        const btnRestart = document.getElementById("btnRestart");
-        btnRestart.onclick = () => {
-          audio.resume();
-          audio.play("uiSelect");
-          overlay.style.display = "none";
-          showWeaponSelectScreen();
+        configureHoldSelection(
+          [btnRestart, submitScoreButton],
+          gameOverHoldGaugeFill,
+        );
+        const attachHoverFocus = (element) => {
+          if (!element) return;
+          element.addEventListener("mouseenter", () => {
+            if (holdSelectionActive) {
+              const index = selectionButtons.indexOf(element);
+              if (index !== -1 && focusedOptionIndex !== index) {
+                focusedOptionIndex = index;
+                highlightFocusedOption();
+                audio.play("uiFocus");
+                return;
+              }
+            }
+            audio.play("uiFocus");
+          });
         };
-        btnRestart.addEventListener("mouseenter", () => {
-          audio.play("uiFocus");
-        });
+        if (btnRestart) {
+          btnRestart.onclick = () => {
+            audio.resume();
+            audio.play("uiSelect");
+            overlay.style.display = "none";
+            clearHoldSelection();
+            showWeaponSelectScreen();
+          };
+          attachHoverFocus(btnRestart);
+        }
+        attachHoverFocus(submitScoreButton);
       }
 
       function sanitizeLeaderboardName(value) {

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -664,7 +664,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       </div>
 
       <div class="bottom-tip" id="tip">TIP: 팁을 보려면 팁을 내세요.</div>
-      <div class="version-label" aria-hidden="true">V25.09.23.00</div>
+      <div class="version-label" aria-hidden="true"></div>
       <div class="levelup-overlay" id="levelupOverlay">
         <div class="levelup-panel">
           <h1>🔶 업그레이드 🔶</h1>
@@ -690,6 +690,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
 
       const APPS_SCRIPT_URL = ""; // 배포된 앱스 스크립트 웹 앱 URL을 여기에 입력하세요
       const LEADERBOARD_NAME_LENGTH = 3;
+      const GAME_VERSION = "V25.09.23.00";
 
       // 게임 초기 상수 값들 (변경이 필요한 경우 여기서만 수정하면 됩니다)
       const INIT = {
@@ -2292,9 +2293,9 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       const muteButton = document.getElementById("muteButton");
 
       const versionLabelEl = document.querySelector(".version-label");
-      const GAME_VERSION = versionLabelEl
-        ? versionLabelEl.textContent.trim()
-        : "";
+      if (versionLabelEl) {
+        versionLabelEl.textContent = GAME_VERSION;
+      }
 
       const tipElem = document.getElementById("tip");
       const tips = [

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -150,6 +150,7 @@
       letter-spacing: 0.08em;
       text-transform: uppercase;
       outline: none;
+      width: calc(6ch + (24px * var(--ui-scale)));
     }
 
     .leaderboard-form input::placeholder {
@@ -3821,7 +3822,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
                 required
               />
             </label>
-            <button type="submit" id="submitScoreButton">리더보드 전송</button>
+            <button type="submit" id="submitScoreButton">기록 하기</button>
             <div id="leaderboardStatus" class="leaderboard-status" aria-live="polite"></div>
           </form>
           <div class="hold-gauge"><div class="fill" id="gameOverHoldGaugeFill"></div></div>

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -2560,6 +2560,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             level,
             elapsedSeconds: elapsed,
             upgrades: upgradeSnapshot,
+            version: GAME_VERSION,
           });
         }, 1000);
       }
@@ -3779,15 +3780,32 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
 
             const rawElapsed = Number(stats.elapsedSeconds ?? 0);
             const elapsedSeconds = Number.isFinite(rawElapsed) ? rawElapsed : 0;
+            const rawWave = Number(stats.wave);
+            const waveValue = Number.isFinite(rawWave) ? rawWave : 0;
+            const rawScore = Number(stats.score);
+            const scoreValue = Number.isFinite(rawScore) ? rawScore : 0;
+            const rawLevel = Number(stats.level);
+            const levelValue = Number.isFinite(rawLevel) ? rawLevel : 1;
+            const weaponValue =
+              typeof stats.weapon === "string" && stats.weapon.trim()
+                ? stats.weapon
+                : "gun";
+            const upgradesValue =
+              stats.upgrades && typeof stats.upgrades === "object"
+                ? { ...stats.upgrades }
+                : {};
+            const submissionDate = new Date().toISOString();
+            const versionValue = `${stats.version || GAME_VERSION || ""}`.trim();
             const payload = {
               name: nickname,
-              wave: stats.wave ?? null,
-              weapon: stats.weapon ?? "",
-              score: stats.score ?? 0,
+              wave: waveValue,
+              weapon: weaponValue,
+              score: scoreValue,
               time: Number(elapsedSeconds.toFixed(2)),
-              level: stats.level ?? null,
-              upgrades: stats.upgrades ?? {},
-              version: stats.version || GAME_VERSION,
+              level: levelValue,
+              upgrades: upgradesValue,
+              version: versionValue,
+              date: submissionDate,
             };
 
             try {


### PR DESCRIPTION
## Summary
- add a configurable Apps Script URL and leaderboard submission form to the game over overlay
- send player stats, upgrades, and version information to the Apps Script backend with a sanitized 3-letter nickname
- adjust keyboard handling and styles so players can type their name without triggering game controls

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d20aa198448332a73f3a6c56493e47