### PR TITLE
Adjust double upgrade badge display

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -405,23 +405,17 @@
       position: absolute;
       top: calc(8px * var(--ui-scale));
       right: calc(8px * var(--ui-scale));
-      background: rgba(14, 19, 48, 0.4);
-      border: 1px solid rgba(255, 235, 205, 0.6);
+      background: rgba(14, 19, 48, 0.65);
+      border: calc(2px * var(--ui-scale)) solid rgba(255, 235, 205, 0.75);
       color: #fff5d7;
-      font-size: calc(10px * var(--ui-scale));
-      font-weight: 700;
-      letter-spacing: 0.05em;
-      padding: calc(2px * var(--ui-scale)) calc(6px * var(--ui-scale));
+      font-size: calc(14px * var(--ui-scale));
+      font-weight: 800;
+      letter-spacing: 0.08em;
+      padding: calc(4px * var(--ui-scale)) calc(12px * var(--ui-scale));
       border-radius: calc(999px * var(--ui-scale));
       text-transform: uppercase;
       pointer-events: none;
-    }
-
-    .upgrade-double-desc {
-      margin-top: calc(6px * var(--ui-scale));
-      font-size: calc(11px * var(--ui-scale));
-      color: #ffe3a3;
-      font-weight: 600;
+      box-shadow: 0 0 calc(12px * var(--ui-scale)) rgba(255, 213, 160, 0.35);
     }
 
     .upgrade-title {
@@ -3510,14 +3504,10 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           const doubleBadge = option.isDouble
             ? `<div class="upgrade-badge">×2</div>`
             : "";
-          const doubleDesc = option.isDouble
-            ? `<div class="upgrade-double-desc">선택 시 <b>${option.title}</b>을 2번 획득합니다!</div>`
-            : "";
           btn.innerHTML = `
             ${doubleBadge}
             <div class="upgrade-title">${option.icon} ${option.title} (${current}/${limitText})</div>
             <div class="upgrade-desc">${option.desc}</div>
-            ${doubleDesc}
         `;
           btn.onclick = () => {
             endHold(false);


### PR DESCRIPTION
## Summary
- enlarge the ×2 badge shown on double upgrade options so it stands out more
- remove the descriptive text that said the upgrade would be obtained twice

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d359a688188332847a46fa7515d910