### PR TITLE
Add ranking panel that loads data from Google Sheets

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -109,6 +109,13 @@
         inset 0 0 60px rgba(49, 86, 212, 0.08);
     }
 
+    .panel.ranking-panel {
+      display: flex;
+      flex-direction: column;
+      gap: calc(12px * var(--ui-scale));
+      max-width: calc(760px * var(--ui-scale));
+    }
+
     .panel h1 {
       margin: 0 0 calc(8px * var(--ui-scale));
       font-weight: 800;
@@ -120,6 +127,60 @@
       margin: calc(6px * var(--ui-scale)) 0;
       line-height: 1.5;
       color: #cfd6ff;
+    }
+
+    .ranking-status {
+      margin: 0;
+      font-size: calc(14px * var(--ui-scale));
+      color: #cfd6ff;
+    }
+
+    .ranking-table-wrapper {
+      border: 1px solid #2e3a7a;
+      border-radius: calc(12px * var(--ui-scale));
+      background: rgba(14, 19, 48, 0.9);
+      max-height: calc(360px * var(--ui-scale));
+      overflow: hidden;
+      overflow-y: auto;
+    }
+
+    .ranking-table-wrapper[hidden] {
+      display: none;
+    }
+
+    .ranking-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: calc(13px * var(--ui-scale));
+      min-width: 100%;
+    }
+
+    .ranking-table thead th {
+      background: #1c2246;
+      font-weight: 700;
+      position: sticky;
+      top: 0;
+      z-index: 1;
+    }
+
+    .ranking-table th,
+    .ranking-table td {
+      padding: calc(8px * var(--ui-scale)) calc(10px * var(--ui-scale));
+      text-align: left;
+      border-bottom: 1px solid #1b2040;
+      white-space: nowrap;
+    }
+
+    .ranking-table tbody tr:nth-child(odd) {
+      background: rgba(28, 34, 70, 0.35);
+    }
+
+    .ranking-table tbody tr:hover {
+      background: rgba(82, 107, 199, 0.35);
+    }
+
+    .ranking-table td {
+      font-weight: 500;
     }
 
     .kbd {
@@ -648,6 +709,19 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       if (versionLabelEl) {
         versionLabelEl.textContent = GAME_VERSION;
       }
+
+      const RANKING_API_URL =
+        "https://script.google.com/macros/s/AKfycbxtgg1ITzAtiOwmiHFkrl1nXTU4LqMQVRR2w_9ki7sf0-rQXftJCwR_uzwoBSZCF49Q/exec";
+      const RANKING_COLUMNS = [
+        { header: "NAME", index: 0 },
+        { header: "WAVE", index: 1 },
+        { header: "WEAPON", index: 2 },
+        { header: "SCORE", index: 3 },
+        { header: "TIME", index: 4 },
+        { header: "LEVEL", index: 5 },
+        { header: "UPGRADES", index: 6 },
+        { header: "REGDATE", index: 7 },
+      ];
 
       // ========================================
       // 게임 밸런스 변수 (수정 편의성을 위해 상단 집중 배치)
@@ -3751,8 +3825,21 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       }
 
       function showRankingScreen() {
+        const headerHTML = RANKING_COLUMNS.map((column) =>
+          `<th>${column.header}</th>`
+        ).join("");
         overlay.innerHTML = `
-        <div class="panel">
+        <div class="panel ranking-panel">
+          <h1>랭킹</h1>
+          <p class="ranking-status" id="rankingStatus">랭킹을 불러오는 중...</p>
+          <div class="ranking-table-wrapper" id="rankingTableWrapper" hidden>
+            <table class="ranking-table">
+              <thead>
+                <tr>${headerHTML}</tr>
+              </thead>
+              <tbody id="rankingTableBody"></tbody>
+            </table>
+          </div>
           <div class="row" id="rankingActions">
             <button id="btnRankingRestart">다시 하기<br>(SPACE)</button>
           </div>
@@ -3763,6 +3850,10 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         overlay.style.display = "flex";
 
         const btnRankingRestart = document.getElementById("btnRankingRestart");
+        const rankingStatus = document.getElementById("rankingStatus");
+        const rankingTableWrapper = document.getElementById("rankingTableWrapper");
+        const rankingTableBody = document.getElementById("rankingTableBody");
+
         selectionButtons = btnRankingRestart ? [btnRankingRestart] : [];
         focusedOptionIndex = 0;
         holdGaugeFill = document.getElementById("rankingHoldGaugeFill");
@@ -3770,6 +3861,88 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         holdGaugeFill.style.width = "0%";
         levelupActive = true;
         updatePauseButton();
+
+        if (rankingStatus) {
+          rankingStatus.hidden = false;
+          rankingStatus.textContent = "랭킹을 불러오는 중...";
+        }
+        if (rankingTableWrapper) {
+          rankingTableWrapper.hidden = true;
+        }
+        if (rankingTableBody) {
+          rankingTableBody.innerHTML = "";
+        }
+
+        const formatRankingValue = (value) => {
+          if (value === null || value === undefined || value === "") {
+            return "-";
+          }
+          if (Array.isArray(value)) {
+            return value.join(", ");
+          }
+          if (typeof value === "number") {
+            return value.toLocaleString("ko-KR");
+          }
+          return String(value);
+        };
+
+        fetch(RANKING_API_URL, { cache: "no-store" })
+          .then((response) => {
+            if (!response.ok) {
+              throw new Error(`HTTP ${response.status}`);
+            }
+            return response.json();
+          })
+          .then((rows) => {
+            if (
+              !rankingStatus ||
+              !rankingTableWrapper ||
+              !rankingTableBody ||
+              !overlay.contains(rankingStatus)
+            ) {
+              return;
+            }
+            if (!Array.isArray(rows)) {
+              throw new Error("Invalid ranking payload");
+            }
+
+            const validRows = rows.filter((row) => Array.isArray(row)).slice(0, 100);
+            if (validRows.length === 0) {
+              rankingStatus.hidden = false;
+              rankingStatus.textContent = "랭킹 데이터가 없습니다.";
+              rankingTableWrapper.hidden = true;
+              rankingTableBody.innerHTML = "";
+              return;
+            }
+
+            rankingTableBody.innerHTML = "";
+            validRows.forEach((row) => {
+              const tr = document.createElement("tr");
+              RANKING_COLUMNS.forEach((column) => {
+                const td = document.createElement("td");
+                const value = column.index < row.length ? row[column.index] : undefined;
+                td.textContent = formatRankingValue(value);
+                tr.appendChild(td);
+              });
+              rankingTableBody.appendChild(tr);
+            });
+
+            rankingStatus.hidden = true;
+            rankingTableWrapper.hidden = false;
+          })
+          .catch((error) => {
+            console.error("Failed to fetch ranking", error);
+            if (
+              !rankingStatus ||
+              !rankingTableWrapper ||
+              !overlay.contains(rankingStatus)
+            ) {
+              return;
+            }
+            rankingStatus.hidden = false;
+            rankingStatus.textContent = "랭킹을 불러오지 못했습니다.";
+            rankingTableWrapper.hidden = true;
+          });
 
         if (btnRankingRestart) {
           btnRankingRestart.addEventListener("mouseenter", () => {

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -181,6 +181,38 @@
 
     .ranking-table td {
       font-weight: 500;
+      vertical-align: middle;
+    }
+
+    .ranking-table th.rank-cell,
+    .ranking-table td.rank-cell {
+      width: calc(56px * var(--ui-scale));
+      text-align: center;
+    }
+
+    .ranking-table td.upgrades-cell,
+    .ranking-table th.upgrades-cell {
+      white-space: normal;
+    }
+
+    .ranking-upgrades {
+      display: flex;
+      flex-wrap: wrap;
+      gap: calc(4px * var(--ui-scale));
+      align-items: center;
+    }
+
+    .ranking-upgrade-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: calc(2px * var(--ui-scale)) calc(4px * var(--ui-scale));
+      border-radius: calc(6px * var(--ui-scale));
+      border: 1px solid #2b356e;
+      background: rgba(14, 19, 48, 0.85);
+      font-size: calc(12px * var(--ui-scale));
+      line-height: 1.1;
+      min-width: calc(20px * var(--ui-scale));
     }
 
     .kbd {
@@ -713,13 +745,25 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       const RANKING_API_URL =
         "https://script.google.com/macros/s/AKfycbxtgg1ITzAtiOwmiHFkrl1nXTU4LqMQVRR2w_9ki7sf0-rQXftJCwR_uzwoBSZCF49Q/exec";
       const RANKING_COLUMNS = [
+        {
+          header: "RANK",
+          headerClass: "rank-cell",
+          cellClass: "rank-cell",
+          render: (_value, _row, rowIndex) => rowIndex + 1,
+        },
         { header: "NAME", index: 0 },
         { header: "WAVE", index: 1 },
         { header: "WEAPON", index: 2 },
         { header: "SCORE", index: 3 },
         { header: "TIME", index: 4 },
         { header: "LEVEL", index: 5 },
-        { header: "UPGRADES", index: 6 },
+        {
+          header: "UPGRADES",
+          index: 6,
+          headerClass: "upgrades-cell",
+          cellClass: "upgrades-cell",
+          render: (value) => buildRankingUpgradesElement(value),
+        },
         { header: "REGDATE", index: 7 },
       ];
 
@@ -3824,10 +3868,270 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         }
       }
 
+      const resolveRankingUpgradeInfo = (() => {
+        let cachedList = null;
+        return (rawId) => {
+          if (!rawId || !UPGRADE_MAP) {
+            return null;
+          }
+          const idText = String(rawId).trim();
+          if (!idText) {
+            return null;
+          }
+          if (UPGRADE_MAP[idText]) {
+            return UPGRADE_MAP[idText];
+          }
+          if (!cachedList) {
+            cachedList = Object.values(UPGRADE_MAP);
+          }
+          const lower = idText.toLowerCase();
+          let match = cachedList.find(
+            (upgrade) => upgrade.id && upgrade.id.toLowerCase() === lower,
+          );
+          if (match) {
+            return match;
+          }
+          match = cachedList.find(
+            (upgrade) =>
+              upgrade.title && upgrade.title.toLowerCase() === lower,
+          );
+          if (match) {
+            return match;
+          }
+          return cachedList.find(
+            (upgrade) => upgrade.icon && upgrade.icon === idText,
+          );
+        };
+      })();
+
+      const normalizeRankingUpgrades = (rawValue) => {
+        const aggregated = new Map();
+
+        const addUpgrade = (id, count = 1) => {
+          const info = resolveRankingUpgradeInfo(id);
+          if (!info) {
+            return;
+          }
+          const numeric =
+            typeof count === "string" ? parseInt(count, 10) : Number(count);
+          const normalizedCount = Number.isFinite(numeric)
+            ? Math.max(1, Math.floor(numeric))
+            : 1;
+          if (normalizedCount <= 0) {
+            return;
+          }
+          const key = info.id || String(id).trim();
+          const label = info.title || key;
+          const icon = info.icon || label.charAt(0) || "";
+          if (aggregated.has(key)) {
+            aggregated.get(key).count += normalizedCount;
+          } else {
+            aggregated.set(key, { icon, count: normalizedCount, label });
+          }
+        };
+
+        const parseToken = (token) => {
+          if (token === null || token === undefined) {
+            return;
+          }
+          const text = String(token).trim();
+          if (!text) {
+            return;
+          }
+          const normalizedText = text.replace(/\s+/g, " ");
+
+          const separators = ["×", "x", "X", "*", ":", "="];
+          for (const separator of separators) {
+            if (normalizedText.includes(separator)) {
+              const parts = normalizedText.split(separator);
+              if (parts.length >= 2) {
+                const rawId = parts[0].trim();
+                const rawCount = parts.slice(1).join(separator).trim();
+                if (rawId) {
+                  const digitsOnly = rawCount.match(/^\d+$/);
+                  if (digitsOnly) {
+                    addUpgrade(rawId, digitsOnly[0]);
+                    return;
+                  }
+                }
+              }
+            }
+          }
+
+          const pairPattern = /([A-Za-z0-9_-]+)\s*(?:×|x|X|\*|:|=)?\s*(\d+)/g;
+          let pairMatched = false;
+          let match;
+          while ((match = pairPattern.exec(normalizedText)) !== null) {
+            pairMatched = true;
+            const [, idPart, countPart] = match;
+            if (idPart) {
+              addUpgrade(idPart, countPart);
+            }
+          }
+          if (pairMatched) {
+            return;
+          }
+
+          const whitespaceParts = normalizedText.split(" ");
+          if (
+            whitespaceParts.length === 2 &&
+            /^\d+$/.test(whitespaceParts[1].trim())
+          ) {
+            addUpgrade(whitespaceParts[0], whitespaceParts[1]);
+            return;
+          }
+
+          addUpgrade(normalizedText, 1);
+        };
+
+        const processValue = (value) => {
+          if (value === null || value === undefined) {
+            return;
+          }
+          if (Array.isArray(value)) {
+            if (
+              value.length === 2 &&
+              typeof value[0] === "string" &&
+              (typeof value[1] === "number" || typeof value[1] === "string")
+            ) {
+              addUpgrade(value[0], value[1]);
+              return;
+            }
+            value.forEach((entry) => {
+              if (
+                Array.isArray(entry) &&
+                entry.length === 2 &&
+                typeof entry[0] === "string"
+              ) {
+                addUpgrade(entry[0], entry[1]);
+              } else {
+                processValue(entry);
+              }
+            });
+            return;
+          }
+          if (typeof value === "object") {
+            const candidateId =
+              value.id ||
+              value.key ||
+              value.name ||
+              value.type ||
+              value.code ||
+              value.slug ||
+              value.upgrade ||
+              value.upgradeId ||
+              value.icon ||
+              value.label;
+            if (candidateId) {
+              const count =
+                value.count ||
+                value.value ||
+                value.amount ||
+                value.qty ||
+                value.quantity ||
+                value.num ||
+                value.times ||
+                value.n ||
+                value.level ||
+                value.rank ||
+                1;
+              addUpgrade(candidateId, count);
+              return;
+            }
+            Object.entries(value).forEach(([key, val]) => {
+              if (val === null || val === undefined || val === "") {
+                return;
+              }
+              if (typeof val === "number" || typeof val === "string") {
+                addUpgrade(key, val);
+                return;
+              }
+              if (Array.isArray(val)) {
+                if (
+                  val.length === 2 &&
+                  typeof val[0] === "string" &&
+                  (typeof val[1] === "number" || typeof val[1] === "string")
+                ) {
+                  addUpgrade(val[0], val[1]);
+                  return;
+                }
+                processValue(val);
+                return;
+              }
+              if (typeof val === "object") {
+                processValue({ ...val, id: val.id || key });
+              }
+            });
+            return;
+          }
+          if (typeof value === "string") {
+            const trimmed = value.trim();
+            if (!trimmed) {
+              return;
+            }
+            if (/^[\[{]/.test(trimmed)) {
+              try {
+                const parsed = JSON.parse(trimmed);
+                processValue(parsed);
+                return;
+              } catch (_error) {
+                // Ignore JSON parse errors and fall back to token parsing
+              }
+            }
+            if (trimmed.includes("|")) {
+              trimmed.split("|").forEach((token) => parseToken(token));
+              return;
+            }
+            if (trimmed.includes(",")) {
+              trimmed.split(",").forEach((token) => parseToken(token));
+              return;
+            }
+            parseToken(trimmed);
+          }
+        };
+
+        processValue(rawValue);
+        return Array.from(aggregated.values());
+      };
+
+      const buildRankingUpgradesElement = (rawValue) => {
+        const upgrades = normalizeRankingUpgrades(rawValue);
+        if (!upgrades.length) {
+          return null;
+        }
+        const container = document.createElement("div");
+        container.className = "ranking-upgrades";
+        const tooltip = upgrades
+          .map(
+            (upgrade) =>
+              `${upgrade.label}${upgrade.count > 1 ? ` ×${upgrade.count}` : ""}`,
+          )
+          .join(", ");
+        if (tooltip) {
+          container.title = tooltip;
+        }
+        upgrades.forEach((upgrade) => {
+          const badge = document.createElement("span");
+          badge.className = "ranking-upgrade-icon";
+          badge.textContent = `${upgrade.icon}${
+            upgrade.count > 1 ? `×${upgrade.count}` : ""
+          }`;
+          badge.setAttribute(
+            "aria-label",
+            `${upgrade.label}${upgrade.count > 1 ? ` ${upgrade.count}회` : ""}`,
+          );
+          container.appendChild(badge);
+        });
+        return container;
+      };
+
       function showRankingScreen() {
-        const headerHTML = RANKING_COLUMNS.map((column) =>
-          `<th>${column.header}</th>`
-        ).join("");
+        const headerHTML = RANKING_COLUMNS.map((column) => {
+          const className = column.headerClass
+            ? ` class="${column.headerClass}"`
+            : "";
+          return `<th${className}>${column.header}</th>`;
+        }).join("");
         overlay.innerHTML = `
         <div class="panel ranking-panel">
           <h1>랭킹</h1>
@@ -3874,7 +4178,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         }
 
         const formatRankingValue = (value) => {
-          if (value === null || value === undefined || value === "") {
+          if (value === null || value === undefined) {
             return "-";
           }
           if (Array.isArray(value)) {
@@ -3882,6 +4186,13 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           }
           if (typeof value === "number") {
             return value.toLocaleString("ko-KR");
+          }
+          if (typeof value === "string") {
+            const trimmed = value.trim();
+            if (!trimmed || trimmed === "[]" || trimmed === "{}") {
+              return "-";
+            }
+            return trimmed;
           }
           return String(value);
         };
@@ -3916,12 +4227,31 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             }
 
             rankingTableBody.innerHTML = "";
-            validRows.forEach((row) => {
+            validRows.forEach((row, rowIndex) => {
               const tr = document.createElement("tr");
               RANKING_COLUMNS.forEach((column) => {
                 const td = document.createElement("td");
-                const value = column.index < row.length ? row[column.index] : undefined;
-                td.textContent = formatRankingValue(value);
+                if (column.cellClass) {
+                  td.classList.add(column.cellClass);
+                }
+                const hasIndex = typeof column.index === "number";
+                const value =
+                  hasIndex && column.index < row.length
+                    ? row[column.index]
+                    : undefined;
+                const rendered =
+                  typeof column.render === "function"
+                    ? column.render(value, row, rowIndex)
+                    : value;
+                if (rendered instanceof Node) {
+                  td.appendChild(rendered);
+                } else {
+                  const fallbackValue =
+                    rendered === null || rendered === undefined
+                      ? value
+                      : rendered;
+                  td.textContent = formatRankingValue(fallbackValue);
+                }
                 tr.appendChild(td);
               });
               rankingTableBody.appendChild(tr);

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -196,23 +196,25 @@
     }
 
     .ranking-upgrades {
-      display: flex;
-      flex-wrap: wrap;
-      gap: calc(4px * var(--ui-scale));
+      display: grid;
+      grid-template-columns: repeat(4, minmax(calc(18px * var(--ui-scale)), 1fr));
+      gap: calc(3px * var(--ui-scale));
       align-items: center;
+      justify-items: center;
     }
 
     .ranking-upgrade-icon {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      padding: calc(2px * var(--ui-scale)) calc(4px * var(--ui-scale));
+      padding: calc(2px * var(--ui-scale));
       border-radius: calc(6px * var(--ui-scale));
       border: 1px solid #2b356e;
       background: rgba(14, 19, 48, 0.85);
-      font-size: calc(12px * var(--ui-scale));
-      line-height: 1.1;
-      min-width: calc(20px * var(--ui-scale));
+      font-size: calc(10px * var(--ui-scale));
+      line-height: 1;
+      min-width: calc(18px * var(--ui-scale));
+      min-height: calc(18px * var(--ui-scale));
     }
 
     .kbd {
@@ -744,6 +746,60 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
 
       const RANKING_API_URL =
         "https://script.google.com/macros/s/AKfycbxtgg1ITzAtiOwmiHFkrl1nXTU4LqMQVRR2w_9ki7sf0-rQXftJCwR_uzwoBSZCF49Q/exec";
+
+      const formatRankingDateParts = (date) => {
+        if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+          return null;
+        }
+        const year = `${date.getFullYear()}`.slice(-2);
+        const month = `${date.getMonth() + 1}`.padStart(2, "0");
+        const day = `${date.getDate()}`.padStart(2, "0");
+        return `${year}.${month}.${day}`;
+      };
+
+      const formatRankingDateValue = (value) => {
+        if (value === null || value === undefined) {
+          return "-";
+        }
+
+        if (value instanceof Date) {
+          const formatted = formatRankingDateParts(value);
+          return formatted || "-";
+        }
+
+        const stringValue = String(value).trim();
+        if (!stringValue) {
+          return "-";
+        }
+
+        const directMatch = stringValue.match(/^([0-9]{4})[-/.]([0-9]{1,2})[-/.]([0-9]{1,2})/);
+        if (directMatch) {
+          const [, year, month, day] = directMatch;
+          return `${year.slice(-2)}.${month.padStart(2, "0")}.${day.padStart(2, "0")}`;
+        }
+
+        if (/^[0-9]{8}$/.test(stringValue)) {
+          const year = stringValue.slice(0, 4);
+          const month = stringValue.slice(4, 6).padStart(2, "0");
+          const day = stringValue.slice(6, 8).padStart(2, "0");
+          return `${year.slice(-2)}.${month}.${day}`;
+        }
+
+        if (/^[0-9]+$/.test(stringValue)) {
+          const numeric = Number(stringValue);
+          if (!Number.isNaN(numeric) && numeric > 0) {
+            const timestamp = stringValue.length > 10 ? numeric : numeric * 1000;
+            const formatted = formatRankingDateParts(new Date(timestamp));
+            if (formatted) {
+              return formatted;
+            }
+          }
+        }
+
+        const parsed = formatRankingDateParts(new Date(stringValue));
+        return parsed || stringValue;
+      };
+
       const RANKING_COLUMNS = [
         {
           header: "RANK",
@@ -764,7 +820,11 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           cellClass: "upgrades-cell",
           render: (value) => buildRankingUpgradesElement(value),
         },
-        { header: "REGDATE", index: 7 },
+        {
+          header: "DATE",
+          index: 7,
+          render: (value) => formatRankingDateValue(value),
+        },
       ];
 
       // ========================================


### PR DESCRIPTION
## Summary
- fetch ranking data from the Google Apps Script endpoint and render it in the ranking panel
- add table styling and layout tweaks for the ranking view
- handle loading, empty, and error states when retrieving the ranking list

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d37c7c134083329ae84d58a66f9790