### PR TITLE
Add cheat to instantly kill the player with digit zero

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -2136,6 +2136,12 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           if (running && !levelupActive) {
             queueBossOrb();
           }
+        } else if (e.code === "Digit0") {
+          e.preventDefault();
+          if (running && hp > 0 && !player.deathAnim.active) {
+            hp = 0;
+            gameOver();
+          }
         }
       });
       window.addEventListener("keyup", (e) => {


### PR DESCRIPTION
## Summary
- add a Digit0 keyboard handler that sets the player's HP to zero and calls the existing game over flow
- guard the cheat so it only triggers during a run and while the death animation has not started

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3ffb28e888332a674579fedc43e80