### PR TITLE
Add ranking panel that fetches ranking data from Apps Script

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -4089,6 +4089,33 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         row.appendChild(cell);
       }
 
+      function stripRankingCurlyBraces(value) {
+        if (value === null || value === undefined) {
+          return "";
+        }
+        let result = String(value).trim();
+        if (!result) {
+          return "";
+        }
+
+        while (
+          result.length > 1 &&
+          result.startsWith("{") &&
+          result.endsWith("}")
+        ) {
+          const inner = result.slice(1, -1).trim();
+          if (!inner) {
+            return inner;
+          }
+          if (tryParseRankingJSON(inner)) {
+            return inner;
+          }
+          result = inner;
+        }
+
+        return result;
+      }
+
       function normalizeRankingUpgrades(rawValue) {
         if (rawValue === null || rawValue === undefined) {
           return [];
@@ -4113,7 +4140,8 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           .replace(/&quot;/g, "\"")
           .replace(/&#34;/g, "\"")
           .replace(/&apos;/g, "'")
-          .replace(/&#39;/g, "'");
+          .replace(/&#39;/g, "'")
+          .trim();
 
         const parsedJSON = tryParseRankingJSON(sanitized);
         if (parsedJSON) {
@@ -4133,14 +4161,16 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             .filter(Boolean);
         }
 
-        const tokens = sanitized
+        const tokenSource = stripRankingCurlyBraces(sanitized);
+
+        const tokens = tokenSource
           .split(/[|;,]/)
           .map((token) => token.trim())
           .filter(Boolean);
 
         if (tokens.length === 0) {
           const single = convertRankingUpgradeEntry(
-            parseStringRankingUpgradeToken(sanitized),
+            parseStringRankingUpgradeToken(tokenSource),
           );
           return single ? [single] : [];
         }

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -169,6 +169,46 @@
       line-height: 1;
     }
 
+    .ranking-table .col-upgrades {
+      font-size: calc(12px * var(--ui-scale));
+      white-space: normal;
+      width: calc(180px * var(--ui-scale));
+      padding: calc(6px * var(--ui-scale)) calc(8px * var(--ui-scale));
+    }
+
+    .ranking-table .col-upgrades .ranking-upgrades {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, calc(32px * var(--ui-scale))));
+      gap: calc(6px * var(--ui-scale));
+      justify-content: center;
+      margin: 0 auto;
+      max-width: calc(184px * var(--ui-scale));
+    }
+
+    .ranking-table .col-upgrades .ranking-upgrade {
+      background: #0e1330aa;
+      border: 1px solid #2b356e;
+      border-radius: calc(8px * var(--ui-scale));
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: calc(3px * var(--ui-scale));
+      padding: calc(4px * var(--ui-scale)) calc(6px * var(--ui-scale));
+      line-height: 1;
+      min-width: calc(28px * var(--ui-scale));
+    }
+
+    .ranking-table .col-upgrades .ranking-upgrade-icon {
+      font-size: calc(16px * var(--ui-scale));
+      line-height: 1;
+    }
+
+    .ranking-table .col-upgrades .ranking-upgrade-count {
+      font-size: calc(11px * var(--ui-scale));
+      color: #cfd6ff;
+      line-height: 1;
+    }
+
     .ranking-table-placeholder {
       padding: calc(24px * var(--ui-scale));
       text-align: center;
@@ -1334,6 +1374,19 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       );
       const UPGRADE_MAP = Object.fromEntries(
         UPGRADES.map((u) => [u.id, u])
+      );
+      const UPGRADE_MAP_LOWERCASE = Object.fromEntries(
+        Object.values(UPGRADE_MAP).map((u) => [u.id.toLowerCase(), u])
+      );
+      const UPGRADE_MAP_BY_TITLE = Object.fromEntries(
+        Object.values(UPGRADE_MAP)
+          .filter((u) => u.title)
+          .map((u) => [u.title, u])
+      );
+      const UPGRADE_MAP_BY_ICON = Object.fromEntries(
+        Object.values(UPGRADE_MAP)
+          .filter((u) => u.icon)
+          .map((u) => [u.icon, u])
       );
 
       const acquiredUpgrades = {};
@@ -3945,7 +3998,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             appendRankingCell(row, formatRankingNumber(entry.score));
             appendRankingCell(row, formatRankingValue(entry.time));
             appendRankingCell(row, formatRankingValue(entry.level));
-            appendRankingCell(row, formatRankingValue(entry.upgrades));
+            appendRankingUpgradesCell(row, entry.upgrades);
             appendRankingCell(row, formatRankingDate(entry.regdate));
             tableBody.appendChild(row);
           });
@@ -3983,6 +4036,310 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           cell.textContent = formatRankingValue(display.name);
         }
         row.appendChild(cell);
+      }
+
+      function appendRankingUpgradesCell(row, upgradesValue) {
+        const cell = document.createElement("td");
+        cell.classList.add("col-upgrades");
+        const normalized = mergeRankingUpgrades(
+          normalizeRankingUpgrades(upgradesValue)
+        );
+        if (normalized.length === 0) {
+          cell.textContent = "-";
+          row.appendChild(cell);
+          return;
+        }
+
+        const container = document.createElement("div");
+        container.className = "ranking-upgrades";
+
+        normalized.forEach(({ icon, label, count }) => {
+          if (!icon) return;
+          const upgradeEl = document.createElement("div");
+          upgradeEl.className = "ranking-upgrade";
+
+          const iconEl = document.createElement("span");
+          iconEl.className = "ranking-upgrade-icon";
+          iconEl.textContent = icon;
+          upgradeEl.appendChild(iconEl);
+
+          if (count > 1) {
+            const countEl = document.createElement("span");
+            countEl.className = "ranking-upgrade-count";
+            countEl.textContent = `×${count}`;
+            upgradeEl.appendChild(countEl);
+          }
+
+          if (label) {
+            const countSuffix = count > 1 ? ` ${count}회` : "";
+            upgradeEl.title = `${label}${countSuffix}`;
+            upgradeEl.setAttribute("aria-label", `${label}${countSuffix}`);
+            upgradeEl.setAttribute("role", "img");
+          }
+
+          container.appendChild(upgradeEl);
+        });
+
+        if (container.children.length === 0) {
+          cell.textContent = "-";
+        } else {
+          cell.appendChild(container);
+        }
+
+        row.appendChild(cell);
+      }
+
+      function normalizeRankingUpgrades(rawValue) {
+        if (rawValue === null || rawValue === undefined) {
+          return [];
+        }
+
+        if (Array.isArray(rawValue)) {
+          return rawValue
+            .map((entry) => convertRankingUpgradeEntry(entry))
+            .filter(Boolean);
+        }
+
+        if (typeof rawValue === "object") {
+          return [convertRankingUpgradeEntry(rawValue)].filter(Boolean);
+        }
+
+        const str = String(rawValue).trim();
+        if (!str || str === "-") {
+          return [];
+        }
+
+        const sanitized = str
+          .replace(/&quot;/g, "\"")
+          .replace(/&#34;/g, "\"")
+          .replace(/&apos;/g, "'")
+          .replace(/&#39;/g, "'");
+
+        const parsedJSON = tryParseRankingJSON(sanitized);
+        if (parsedJSON) {
+          const candidate = Array.isArray(parsedJSON)
+            ? parsedJSON
+            : Array.isArray(parsedJSON.upgrades)
+              ? parsedJSON.upgrades
+              : typeof parsedJSON === "object"
+                ? Object.entries(parsedJSON).map(([id, value]) =>
+                    typeof value === "object" && value !== null
+                      ? { id, ...value }
+                      : { id, count: value },
+                  )
+                : [];
+          return candidate
+            .map((entry) => convertRankingUpgradeEntry(entry))
+            .filter(Boolean);
+        }
+
+        const tokens = sanitized
+          .split(/[|;,]/)
+          .map((token) => token.trim())
+          .filter(Boolean);
+
+        if (tokens.length === 0) {
+          const single = convertRankingUpgradeEntry(
+            parseStringRankingUpgradeToken(sanitized),
+          );
+          return single ? [single] : [];
+        }
+
+        return tokens
+          .map((token) =>
+            convertRankingUpgradeEntry(parseStringRankingUpgradeToken(token)),
+          )
+          .filter(Boolean);
+      }
+
+      function mergeRankingUpgrades(entries) {
+        const merged = [];
+        const byId = new Map();
+        entries.forEach((entry) => {
+          if (!entry) return;
+          const key = entry.id || `${entry.icon}|${entry.label}`;
+          if (!key) return;
+          if (byId.has(key)) {
+            byId.get(key).count += entry.count;
+          } else {
+            const copy = { ...entry };
+            byId.set(key, copy);
+            merged.push(copy);
+          }
+        });
+        return merged;
+      }
+
+      function convertRankingUpgradeEntry(entry) {
+        if (!entry) return null;
+
+        if (typeof entry === "string") {
+          return convertRankingUpgradeEntry(
+            parseStringRankingUpgradeToken(entry),
+          );
+        }
+
+        if (Array.isArray(entry)) {
+          if (entry.length === 0) return null;
+          const [idValue, countValue, iconValue] = entry;
+          return convertRankingUpgradeEntry({
+            id: idValue,
+            count: countValue,
+            icon: iconValue,
+          });
+        }
+
+        if (typeof entry !== "object") {
+          return null;
+        }
+
+        const idValue =
+          entry.id ??
+          entry.key ??
+          entry.code ??
+          entry.name ??
+          entry.title ??
+          entry.icon ??
+          entry.symbol ??
+          "";
+        const iconValue = entry.icon ?? entry.symbol ?? "";
+        const labelValue =
+          entry.title ?? entry.name ?? entry.label ?? entry.id ?? "";
+        const countValue =
+          entry.count ??
+          entry.value ??
+          entry.qty ??
+          entry.quantity ??
+          entry.times ??
+          entry.amount ??
+          entry.level ??
+          entry.num ??
+          entry[1];
+
+        const id =
+          typeof idValue === "string" || typeof idValue === "number"
+            ? String(idValue).trim()
+            : "";
+        const icon = typeof iconValue === "string" ? iconValue : "";
+        const label = typeof labelValue === "string" ? labelValue : "";
+
+        let count = Number(countValue);
+        if (!Number.isFinite(count) || count <= 0) {
+          count = 1;
+        } else {
+          count = Math.floor(count);
+        }
+
+        const display = resolveRankingUpgradeDisplay(id, icon, label || id);
+        const finalId = display.id || id || icon || label;
+        const finalIcon = display.icon || icon || id;
+        const finalLabel = display.label || label || finalIcon || finalId;
+
+        if (!finalIcon && !finalLabel) {
+          return null;
+        }
+
+        return {
+          id: finalId,
+          icon: finalIcon,
+          label: finalLabel,
+          count,
+        };
+      }
+
+      function parseStringRankingUpgradeToken(token) {
+        if (!token) return null;
+        const trimmed = String(token).trim();
+        if (!trimmed) return null;
+
+        if (/^[\[{]/.test(trimmed)) {
+          const parsed = tryParseRankingJSON(trimmed);
+          if (parsed) {
+            return parsed;
+          }
+        }
+
+        const match = trimmed.match(/^(.*?)(?:\s*[xX×*:=]\s*)(\d+)\s*$/);
+        if (match) {
+          return { id: match[1].trim(), count: Number(match[2]) };
+        }
+
+        return { id: trimmed, count: 1 };
+      }
+
+      function resolveRankingUpgradeDisplay(rawId, fallbackIcon, fallbackLabel) {
+        const idStr = rawId ? String(rawId).trim() : "";
+        let upgrade = null;
+        if (idStr) {
+          upgrade =
+            UPGRADE_MAP[idStr] ||
+            UPGRADE_MAP_LOWERCASE[idStr.toLowerCase()] ||
+            UPGRADE_MAP_BY_TITLE[idStr] ||
+            UPGRADE_MAP_BY_ICON[idStr];
+        }
+
+        if (upgrade) {
+          return {
+            id: upgrade.id,
+            icon: upgrade.icon || fallbackIcon || idStr,
+            label: upgrade.title || fallbackLabel || idStr,
+          };
+        }
+
+        if (fallbackIcon) {
+          return {
+            id: idStr || fallbackIcon,
+            icon: fallbackIcon,
+            label: fallbackLabel || idStr || fallbackIcon,
+          };
+        }
+
+        if (idStr) {
+          return {
+            id: idStr,
+            icon: idStr,
+            label: fallbackLabel || idStr,
+          };
+        }
+
+        return {
+          id: "",
+          icon: "",
+          label: fallbackLabel || "",
+        };
+      }
+
+      function tryParseRankingJSON(str) {
+        if (!str) return null;
+        const trimmed = String(str).trim();
+        if (!trimmed) return null;
+        if (!/^[\[{]/.test(trimmed)) {
+          return null;
+        }
+
+        const attempts = [trimmed];
+        if (trimmed.startsWith("{") && trimmed.includes("},{")) {
+          attempts.push(`[${trimmed}]`);
+        }
+        if (!trimmed.includes('"') && trimmed.includes("'")) {
+          attempts.push(trimmed.replace(/'/g, '"'));
+        }
+
+        for (const attempt of attempts) {
+          try {
+            const parsed = JSON.parse(attempt);
+            if (Array.isArray(parsed)) {
+              return parsed;
+            }
+            if (parsed && typeof parsed === "object") {
+              return parsed;
+            }
+          } catch (error) {
+            continue;
+          }
+        }
+
+        return null;
       }
 
       function formatRankingValue(value) {

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -116,6 +116,60 @@
       max-width: calc(760px * var(--ui-scale));
     }
 
+    .ranking-table-container {
+      border: 1px solid #1c2452;
+      border-radius: calc(12px * var(--ui-scale));
+      overflow: auto;
+      max-height: calc(360px * var(--ui-scale));
+      background: rgba(8, 12, 32, 0.65);
+    }
+
+    .ranking-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: calc(14px * var(--ui-scale));
+    }
+
+    .ranking-table th,
+    .ranking-table td {
+      padding: calc(8px * var(--ui-scale)) calc(10px * var(--ui-scale));
+      border-bottom: 1px solid #1c2452;
+      text-align: center;
+      white-space: nowrap;
+    }
+
+    .ranking-table th {
+      background: #141a3a;
+      color: #9fb3ff;
+      font-weight: 700;
+      letter-spacing: calc(0.5px * var(--ui-scale));
+    }
+
+    .ranking-table tbody tr:nth-child(odd) {
+      background: rgba(17, 22, 49, 0.6);
+    }
+
+    .ranking-table tbody tr:nth-child(even) {
+      background: rgba(12, 16, 38, 0.6);
+    }
+
+    .ranking-table td {
+      color: #e4e9ff;
+    }
+
+    .ranking-table .col-name {
+      text-align: left;
+      max-width: calc(160px * var(--ui-scale));
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .ranking-table-placeholder {
+      padding: calc(24px * var(--ui-scale));
+      text-align: center;
+      color: #9fa8d8;
+    }
+
     .panel h1 {
       margin: 0 0 calc(8px * var(--ui-scale));
       font-weight: 800;
@@ -651,6 +705,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
   <script>
     (() => {
       const GAME_VERSION = "V25.09.24.01";
+      const RANKING_API_URL = "https://script.google.com/macros/s/AKfycbzUjrfjVekxS7TV4hxSFoljwbZ-hKyXnG93J2roTyidNrsBRHOb-lboPMsk1BYzv88b/exec";
       const versionLabelEl = document.getElementById("versionLabel");
       if (versionLabelEl) {
         versionLabelEl.textContent = GAME_VERSION;
@@ -3779,7 +3834,29 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       function showRankingScreen() {
         overlay.innerHTML = `
         <div class="panel ranking-panel">
-          <h1>게임 다시 하기</h1>
+          <h1>랭킹</h1>
+          <div class="ranking-table-container">
+            <table class="ranking-table">
+              <thead>
+                <tr>
+                  <th>RANK</th>
+                  <th>NAME</th>
+                  <th>WAVE</th>
+                  <th>WEAPON</th>
+                  <th>SCORE</th>
+                  <th>TIME</th>
+                  <th>LEVEL</th>
+                  <th>UPGRADES</th>
+                  <th>DATE</th>
+                </tr>
+              </thead>
+              <tbody id="rankingTableBody">
+                <tr>
+                  <td class="ranking-table-placeholder" colspan="9">랭킹 데이터를 불러오는 중...</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
           <div class="row" id="rankingActions">
             <button id="btnRankingRestart">다시 하기<br>(SPACE)</button>
           </div>
@@ -3803,6 +3880,8 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         levelupActive = true;
         updatePauseButton();
 
+        loadRankingData();
+
         if (btnRankingRestart) {
           btnRankingRestart.addEventListener("mouseenter", () => {
             if (focusedOptionIndex !== 0) {
@@ -3822,6 +3901,129 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             showWeaponSelectScreen();
           };
         }
+      }
+
+      async function loadRankingData() {
+        const tableBody = document.getElementById("rankingTableBody");
+        if (!tableBody) return;
+
+        tableBody.innerHTML = `
+          <tr>
+            <td class="ranking-table-placeholder" colspan="9">랭킹 데이터를 불러오는 중...</td>
+          </tr>
+        `;
+
+        try {
+          const response = await fetch(RANKING_API_URL, { cache: "no-store" });
+          if (!response.ok) {
+            throw new Error(`Failed to load: ${response.status}`);
+          }
+
+          const data = await response.json();
+
+          if (!Array.isArray(data) || data.length === 0) {
+            tableBody.innerHTML = `
+              <tr>
+                <td class="ranking-table-placeholder" colspan="9">등록된 랭킹 데이터가 없습니다.</td>
+              </tr>
+            `;
+            return;
+          }
+
+          tableBody.innerHTML = "";
+          data.forEach(entry => {
+            const row = document.createElement("tr");
+            appendRankingCell(row, formatRankingValue(entry.rank));
+            appendRankingCell(row, formatRankingValue(entry.name), "col-name");
+            appendRankingCell(row, formatRankingValue(entry.wave));
+            appendRankingCell(row, formatRankingValue(entry.weapon));
+            appendRankingCell(row, formatRankingNumber(entry.score));
+            appendRankingCell(row, formatRankingValue(entry.time));
+            appendRankingCell(row, formatRankingValue(entry.level));
+            appendRankingCell(row, formatRankingValue(entry.upgrades));
+            appendRankingCell(row, formatRankingDate(entry.regdate));
+            tableBody.appendChild(row);
+          });
+        } catch (error) {
+          console.error(error);
+          tableBody.innerHTML = `
+            <tr>
+              <td class="ranking-table-placeholder" colspan="9">랭킹을 불러오지 못했습니다.</td>
+            </tr>
+          `;
+        }
+      }
+
+      function appendRankingCell(row, value, className) {
+        const cell = document.createElement("td");
+        if (className) {
+          cell.classList.add(className);
+        }
+        cell.textContent = value;
+        row.appendChild(cell);
+      }
+
+      function formatRankingValue(value) {
+        if (value === null || value === undefined) return "-";
+        const str = String(value).trim();
+        return str.length > 0 ? str : "-";
+      }
+
+      function formatRankingNumber(value) {
+        const num = Number(value);
+        if (!Number.isNaN(num)) {
+          return num.toLocaleString();
+        }
+        return formatRankingValue(value);
+      }
+
+      function formatRankingDate(regdate) {
+        if (regdate === null || regdate === undefined) return "-";
+        const str = String(regdate).trim();
+        if (!str) return "-";
+
+        const match = str.match(/(\d{2,4})[./-](\d{1,2})[./-](\d{1,2})/);
+        if (match) {
+          let [, year, month, day] = match;
+          if (year.length === 4) {
+            year = year.slice(2);
+          } else if (year.length > 2) {
+            year = year.slice(-2);
+          }
+          month = month.padStart(2, "0");
+          day = day.padStart(2, "0");
+          return `${year}.${month}.${day}`;
+        }
+
+        const numeric = Number(str);
+        if (!Number.isNaN(numeric)) {
+          if (numeric > 1e12) {
+            return formatDateFromTimestamp(numeric);
+          }
+          if (numeric > 1e9) {
+            return formatDateFromTimestamp(numeric * 1000);
+          }
+          if (numeric > 1000) {
+            const excelEpoch = Date.UTC(1899, 11, 30);
+            return formatDateFromTimestamp(excelEpoch + numeric * 86400000);
+          }
+        }
+
+        const parsed = new Date(str);
+        if (!Number.isNaN(parsed.getTime())) {
+          return formatDateFromTimestamp(parsed.getTime());
+        }
+
+        return str;
+      }
+
+      function formatDateFromTimestamp(timestamp) {
+        const date = new Date(timestamp);
+        if (Number.isNaN(date.getTime())) return "-";
+        const year = String(date.getFullYear()).slice(-2);
+        const month = String(date.getMonth() + 1).padStart(2, "0");
+        const day = String(date.getDate()).padStart(2, "0");
+        return `${year}.${month}.${day}`;
       }
 
       // --- 업데이트 ---

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -164,6 +164,11 @@
       text-overflow: ellipsis;
     }
 
+    .ranking-table .col-weapon {
+      font-size: calc(18px * var(--ui-scale));
+      line-height: 1;
+    }
+
     .ranking-table-placeholder {
       padding: calc(24px * var(--ui-scale));
       text-align: center;
@@ -3936,7 +3941,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             appendRankingCell(row, formatRankingValue(entry.rank));
             appendRankingCell(row, formatRankingValue(entry.name), "col-name");
             appendRankingCell(row, formatRankingValue(entry.wave));
-            appendRankingCell(row, formatRankingValue(entry.weapon));
+            appendRankingWeaponCell(row, entry.weapon);
             appendRankingCell(row, formatRankingNumber(entry.score));
             appendRankingCell(row, formatRankingValue(entry.time));
             appendRankingCell(row, formatRankingValue(entry.level));
@@ -3960,6 +3965,23 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           cell.classList.add(className);
         }
         cell.textContent = value;
+        row.appendChild(cell);
+      }
+
+      function appendRankingWeaponCell(row, weaponId) {
+        const cell = document.createElement("td");
+        cell.classList.add("col-weapon");
+        const display = getWeaponDisplay(weaponId);
+        if (display.icon) {
+          cell.textContent = display.icon;
+          if (display.name && display.name !== "-") {
+            cell.title = display.name;
+            cell.setAttribute("aria-label", display.name);
+            cell.setAttribute("role", "img");
+          }
+        } else {
+          cell.textContent = formatRankingValue(display.name);
+        }
         row.appendChild(cell);
       }
 


### PR DESCRIPTION
## Summary
- add styling for the ranking table shown on the game over ranking screen
- fetch ranking data from the Google Apps Script endpoint and render the table columns
- format scores and registration dates (YY.MM.DD) before displaying them in the table

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d404ba39fc833298d5e707c9f5927c