### PR TITLE
Fix ranking overlay layout to stay within the game viewport

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -319,6 +319,14 @@
       border: 1px solid #7ea0ff55;
     }
 
+    .overlay button {
+      font-size: calc(14px * var(--overlay-scale));
+      padding: calc(12px * var(--overlay-scale))
+        calc(18px * var(--overlay-scale));
+      border-radius: calc(12px * var(--overlay-scale));
+      min-width: calc(120px * var(--overlay-scale));
+    }
+
     button:hover {
       transform: translateY(calc(-1px * var(--ui-scale)));
       filter: brightness(1.05);


### PR DESCRIPTION
## Summary
- scale the overlay padding with the shared UI scale variable so overlays respect the canvas size
- constrain the ranking panel height and flex its table container to keep the panel within the game viewport

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4c26beeec83328bf90030dcdb75a4