### PR TITLE
Adjust ranking table layout

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -189,7 +189,7 @@
     .ranking-table {
       width: 100%;
       border-collapse: collapse;
-      font-size: calc(14px * var(--ui-scale));
+      font-size: calc(13px * var(--ui-scale));
     }
 
     .ranking-table th,
@@ -234,7 +234,7 @@
     .ranking-table .col-upgrades {
       font-size: calc(12px * var(--ui-scale));
       white-space: normal;
-      width: calc(180px * var(--ui-scale));
+      width: calc(220px * var(--ui-scale));
       padding: calc(6px * var(--ui-scale)) calc(8px * var(--ui-scale));
     }
 
@@ -244,7 +244,7 @@
       gap: calc(6px * var(--ui-scale));
       justify-content: center;
       margin: 0 auto;
-      max-width: calc(184px * var(--ui-scale));
+      max-width: calc(232px * var(--ui-scale));
     }
 
     .ranking-table .col-upgrades .ranking-upgrade {

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -254,7 +254,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      gap: calc(3px * var(--ui-scale));
+      gap: 0;
       padding: calc(4px * var(--ui-scale)) calc(6px * var(--ui-scale));
       line-height: 1;
       min-width: calc(22px * var(--ui-scale));


### PR DESCRIPTION
## Summary
- reduce the ranking table's base font size to create more room for columns
- expand the upgrades column width and grid to prevent overlapping icons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4cc38cbf883328af9e7f18bc20806