### PR TITLE
Add ranking view modal and buttons

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -4002,7 +4002,6 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           <div class="row" id="gameoverActions">
             <button id="btnRestart">다시 하기<br></button>
             <button id="btnRegisterRanking">전당 등록<br></button>
-            <button id="btnViewRankingGameover">전당 보기<br></button>
           </div>
           <div class="hold-gauge">
             <div class="fill" id="gameoverHoldGaugeFill"></div>
@@ -4012,14 +4011,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
 
         const btnRestart = document.getElementById("btnRestart");
         const btnRegisterRanking = document.getElementById("btnRegisterRanking");
-        const btnViewRankingGameover = document.getElementById(
-          "btnViewRankingGameover",
-        );
-        const actionButtons = [
-          btnRestart,
-          btnRegisterRanking,
-          btnViewRankingGameover,
-        ].filter(Boolean);
+        const actionButtons = [btnRestart, btnRegisterRanking].filter(Boolean);
 
         selectionButtons = actionButtons;
         focusedOptionIndex = 0;
@@ -4061,18 +4053,6 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           };
         }
 
-        if (btnViewRankingGameover) {
-          const reopenGameOver = () => {
-            showGameOverScreen(stats);
-          };
-          btnViewRankingGameover.onclick = () => {
-            endHold(false);
-            audio.resume();
-            audio.play("uiSelect");
-            levelupActive = false;
-            showRankingScreen({ mode: "view", onClose: reopenGameOver });
-          };
-        }
       }
 
       function showRankingScreen(options = {}) {

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -3879,14 +3879,16 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           <p><span class="kbd">좌클릭</span> 또는 <span class="kbd">스페이스바</span>로 <b>방향 전환</b></p>
           <p><span class="kbd">스페이스바</span> <b>길게 누르기</b> : 게임 시작</p>
           <div class="row"><button id="btnStart" type="button">게임 시작<br>(SPACE)</button></div>
+          <div class="row"><button id="btnViewRankingStart" type="button">전당 보기<br></button></div>
           <div class="hold-gauge"><div class="fill" id="startHoldGaugeFill"></div></div>
         </div>`;
         overlay.style.display = "flex";
 
         const btnStart = document.getElementById("btnStart");
+        const btnViewRankingStart = document.getElementById("btnViewRankingStart");
         const startGauge = document.getElementById("startHoldGaugeFill");
 
-        selectionButtons = btnStart ? [btnStart] : [];
+        selectionButtons = [btnStart, btnViewRankingStart].filter(Boolean);
         focusedOptionIndex = 0;
         holdGaugeFill = startGauge;
         if (holdGaugeFill) {
@@ -3915,6 +3917,28 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
               highlightFocusedOption();
             }
             audio.play("uiFocus");
+          });
+        }
+
+        if (btnViewRankingStart) {
+          const targetIndex = selectionButtons.indexOf(btnViewRankingStart);
+          btnViewRankingStart.onclick = () => {
+            endHold(false);
+            audio.play("uiSelect");
+            levelupActive = false;
+            showRankingScreen({
+              mode: "view",
+              onClose: () => {
+                showStartScreen();
+              },
+            });
+          };
+          btnViewRankingStart.addEventListener("mouseenter", () => {
+            if (focusedOptionIndex !== targetIndex) {
+              focusedOptionIndex = targetIndex;
+              highlightFocusedOption();
+              audio.play("uiFocus");
+            }
           });
         }
       }
@@ -3977,7 +4001,8 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           ${upgradeSectionHTML}
           <div class="row" id="gameoverActions">
             <button id="btnRestart">다시 하기<br></button>
-            <button id="btnShowRanking">전당 등록<br></button>
+            <button id="btnRegisterRanking">전당 등록<br></button>
+            <button id="btnViewRankingGameover">전당 보기<br></button>
           </div>
           <div class="hold-gauge">
             <div class="fill" id="gameoverHoldGaugeFill"></div>
@@ -3986,8 +4011,15 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         overlay.style.display = "flex";
 
         const btnRestart = document.getElementById("btnRestart");
-        const btnShowRanking = document.getElementById("btnShowRanking");
-        const actionButtons = [btnRestart, btnShowRanking].filter(Boolean);
+        const btnRegisterRanking = document.getElementById("btnRegisterRanking");
+        const btnViewRankingGameover = document.getElementById(
+          "btnViewRankingGameover",
+        );
+        const actionButtons = [
+          btnRestart,
+          btnRegisterRanking,
+          btnViewRankingGameover,
+        ].filter(Boolean);
 
         selectionButtons = actionButtons;
         focusedOptionIndex = 0;
@@ -4019,8 +4051,8 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           };
         }
 
-        if (btnShowRanking) {
-          btnShowRanking.onclick = () => {
+        if (btnRegisterRanking) {
+          btnRegisterRanking.onclick = () => {
             endHold(false);
             audio.resume();
             audio.play("uiSelect");
@@ -4028,12 +4060,30 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             showRankingScreen();
           };
         }
+
+        if (btnViewRankingGameover) {
+          const reopenGameOver = () => {
+            showGameOverScreen(stats);
+          };
+          btnViewRankingGameover.onclick = () => {
+            endHold(false);
+            audio.resume();
+            audio.play("uiSelect");
+            levelupActive = false;
+            showRankingScreen({ mode: "view", onClose: reopenGameOver });
+          };
+        }
       }
 
-      function showRankingScreen() {
+      function showRankingScreen(options = {}) {
+        const { mode = "register", onClose = null } = options || {};
+        const isViewMode = mode === "view";
         const playerRankMessage = lastGameStats
           ? "내 기록 순위를 계산 중..."
           : "플레이 기록이 없습니다.";
+        const actionButtonHTML = isViewMode
+          ? `<button id="btnRankingClose">닫기<br>(SPACE)</button>`
+          : `<button id="btnRankingRestart">다시 하기<br>(SPACE)</button>`;
         overlay.innerHTML = `
         <div class="panel ranking-panel">
           <h1>영웅의 전당</h1>
@@ -4060,34 +4110,48 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             </table>
           </div>
           <p class="player-rank-info" id="playerRankInfo">${playerRankMessage}</p>
-          <div class="player-name-submit" id="playerNameSubmit">
+          ${
+            isViewMode
+              ? ""
+              : `<div class=\"player-name-submit\" id=\"playerNameSubmit\">
             <input
-              id="playerNameInput"
-              type="text"
-              inputmode="text"
-              maxlength="3"
-              placeholder="ABC"
-              aria-label="이름 입력"
-              pattern="[A-Za-z0-9]*"
-              autocomplete="off"
-              autocorrect="off"
-              spellcheck="false"
+              id=\"playerNameInput\"
+              type=\"text\"
+              inputmode=\"text\"
+              maxlength=\"3\"
+              placeholder=\"ABC\"
+              aria-label=\"이름 입력\"
+              pattern=\"[A-Za-z0-9]*\"
+              autocomplete=\"off\"
+              autocorrect=\"off\"
+              spellcheck=\"false\"
             />
-            <button id="btnEngraveScore" type="button">새기기</button>
-          </div>
+            <button id=\"btnEngraveScore\" type=\"button\">새기기</button>
+          </div>`
+          }
           <div class="row" id="rankingActions">
-            <button id="btnRankingRestart">다시 하기<br>(SPACE)</button>
+            ${actionButtonHTML}
           </div>
           <div class="hold-gauge">
             <div class="fill" id="rankingHoldGaugeFill"></div>
           </div>
         </div>`;
         overlay.style.display = "flex";
-        initializePlayerNameInput();
+
+        if (!isViewMode) {
+          initializePlayerNameInput();
+        }
 
         const btnRankingRestart = document.getElementById("btnRankingRestart");
+        const btnRankingClose = document.getElementById("btnRankingClose");
 
-        selectionButtons = btnRankingRestart ? [btnRankingRestart] : [];
+        if (btnRankingRestart) {
+          selectionButtons = [btnRankingRestart];
+        } else if (btnRankingClose) {
+          selectionButtons = [btnRankingClose];
+        } else {
+          selectionButtons = [];
+        }
         focusedOptionIndex = 0;
         holdGaugeFill = document.getElementById("rankingHoldGaugeFill");
         if (selectionButtons.length > 0) {
@@ -4099,7 +4163,9 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         levelupActive = true;
         updatePauseButton();
 
-        loadRankingData(lastGameStats);
+        const playerStatsForRanking =
+          options.playerStats !== undefined ? options.playerStats : lastGameStats;
+        loadRankingData(playerStatsForRanking);
 
         if (btnRankingRestart) {
           btnRankingRestart.addEventListener("mouseenter", () => {
@@ -4118,6 +4184,29 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             levelupActive = false;
             updatePauseButton();
             showWeaponSelectScreen();
+          };
+        }
+
+        if (btnRankingClose) {
+          btnRankingClose.addEventListener("mouseenter", () => {
+            if (focusedOptionIndex !== 0) {
+              focusedOptionIndex = 0;
+              highlightFocusedOption();
+              audio.play("uiFocus");
+            }
+          });
+
+          btnRankingClose.onclick = () => {
+            endHold(false);
+            audio.resume();
+            audio.play("uiSelect");
+            levelupActive = false;
+            updatePauseButton();
+            if (typeof onClose === "function") {
+              onClose();
+            } else {
+              overlay.style.display = "none";
+            }
           };
         }
       }

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -2734,6 +2734,8 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         setTimeout(() => {
           running = false;
           updatePauseButton();
+          hasSubmittedCurrentRecord = false;
+          isSubmittingRank = false;
           const minutes = Math.floor(elapsed / 60);
           const secondsLabel = (elapsed % 60).toFixed(2).padStart(5, "0");
           const finalStats = {
@@ -3990,6 +3992,13 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         const upgradeSectionHTML = buildGameOverUpgradeSection(
           stats.upgrades || []
         );
+        const hasSubmittedRecord = hasSubmittedCurrentRecord === true;
+        const registerButtonHTML = hasSubmittedRecord
+          ? `<button id="btnRegisterRanking" data-mode="view">전당 보기<br></button>`
+          : `<button id="btnRegisterRanking">전당 등록<br></button>`;
+        const viewButtonHTML = hasSubmittedRecord
+          ? ""
+          : `<button id="btnViewRankingResults">전당 보기<br></button>`;
         overlay.innerHTML = `
         <div class="panel">
           <h1>🕊️ 전쟁이 끝났습니다 🕊️</h1>
@@ -4001,7 +4010,8 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           ${upgradeSectionHTML}
           <div class="row" id="gameoverActions">
             <button id="btnRestart">다시 하기<br></button>
-            <button id="btnRegisterRanking">전당 등록<br></button>
+            ${registerButtonHTML}
+            ${viewButtonHTML}
           </div>
           <div class="hold-gauge">
             <div class="fill" id="gameoverHoldGaugeFill"></div>
@@ -4011,7 +4021,14 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
 
         const btnRestart = document.getElementById("btnRestart");
         const btnRegisterRanking = document.getElementById("btnRegisterRanking");
-        const actionButtons = [btnRestart, btnRegisterRanking].filter(Boolean);
+        const btnViewRankingResults = document.getElementById(
+          "btnViewRankingResults"
+        );
+        const actionButtons = [
+          btnRestart,
+          btnRegisterRanking,
+          btnViewRankingResults,
+        ].filter(Boolean);
 
         selectionButtons = actionButtons;
         focusedOptionIndex = 0;
@@ -4049,7 +4066,31 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             audio.resume();
             audio.play("uiSelect");
             levelupActive = false;
-            showRankingScreen();
+            const mode =
+              btnRegisterRanking.dataset.mode === "view" ? "view" : "register";
+            showRankingScreen({
+              mode,
+              playerStats: stats,
+              onClose: () => {
+                showGameOverScreen(stats);
+              },
+            });
+          };
+        }
+
+        if (btnViewRankingResults) {
+          btnViewRankingResults.onclick = () => {
+            endHold(false);
+            audio.resume();
+            audio.play("uiSelect");
+            levelupActive = false;
+            showRankingScreen({
+              mode: "view",
+              playerStats: stats,
+              onClose: () => {
+                showGameOverScreen(stats);
+              },
+            });
           };
         }
 
@@ -4061,9 +4102,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         const playerRankMessage = lastGameStats
           ? "내 기록 순위를 계산 중..."
           : "플레이 기록이 없습니다.";
-        const actionButtonHTML = isViewMode
-          ? `<button id="btnRankingClose">닫기<br>(SPACE)</button>`
-          : `<button id="btnRankingRestart">다시 하기<br>(SPACE)</button>`;
+        const actionButtonHTML = `<button id="btnRankingClose">닫기<br>(SPACE)</button>`;
         overlay.innerHTML = `
         <div class="panel ranking-panel">
           <h1>영웅의 전당</h1>
@@ -4122,16 +4161,9 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           initializePlayerNameInput();
         }
 
-        const btnRankingRestart = document.getElementById("btnRankingRestart");
         const btnRankingClose = document.getElementById("btnRankingClose");
 
-        if (btnRankingRestart) {
-          selectionButtons = [btnRankingRestart];
-        } else if (btnRankingClose) {
-          selectionButtons = [btnRankingClose];
-        } else {
-          selectionButtons = [];
-        }
+        selectionButtons = btnRankingClose ? [btnRankingClose] : [];
         focusedOptionIndex = 0;
         holdGaugeFill = document.getElementById("rankingHoldGaugeFill");
         if (selectionButtons.length > 0) {
@@ -4146,26 +4178,6 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         const playerStatsForRanking =
           options.playerStats !== undefined ? options.playerStats : lastGameStats;
         loadRankingData(playerStatsForRanking);
-
-        if (btnRankingRestart) {
-          btnRankingRestart.addEventListener("mouseenter", () => {
-            if (focusedOptionIndex !== 0) {
-              focusedOptionIndex = 0;
-              highlightFocusedOption();
-              audio.play("uiFocus");
-            }
-          });
-
-          btnRankingRestart.onclick = () => {
-            endHold(false);
-            audio.resume();
-            audio.play("uiSelect");
-            overlay.style.display = "none";
-            levelupActive = false;
-            updatePauseButton();
-            showWeaponSelectScreen();
-          };
-        }
 
         if (btnRankingClose) {
           btnRankingClose.addEventListener("mouseenter", () => {

--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -3994,11 +3994,11 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         );
         const hasSubmittedRecord = hasSubmittedCurrentRecord === true;
         const registerButtonHTML = hasSubmittedRecord
-          ? `<button id="btnRegisterRanking" data-mode="view">전당 보기<br></button>`
+          ? ""
           : `<button id="btnRegisterRanking">전당 등록<br></button>`;
         const viewButtonHTML = hasSubmittedRecord
-          ? ""
-          : `<button id="btnViewRankingResults">전당 보기<br></button>`;
+          ? `<button id="btnViewRankingResults">전당 보기<br></button>`
+          : "";
         overlay.innerHTML = `
         <div class="panel">
           <h1>🕊️ 전쟁이 끝났습니다 🕊️</h1>


### PR DESCRIPTION
## Summary
- add a hall-of-fame viewing button to the start panel so players can open the ranking modal before playing
- update the game over panel with separate buttons for ranking registration and viewing
- extend the ranking screen with a view-only modal variant that includes a hold-to-close button

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4f46557cc8332896e342fa10aa2ca