### PR TITLE
Enable first registration when hall is empty

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -4485,7 +4485,11 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         }
 
         if (rankingData.length === 0) {
-          setPlayerRankInfoMessage("전당 문이 잠겨있어 확인할 수 없습니다.");
+          setPlayerRankInfoMessage("1번째로 전당에 이름을 새길 수 있습니다.");
+          if (!hasSubmittedCurrentRecord) {
+            setPlayerNameSubmitVisible(true);
+            focusPlayerNameInput();
+          }
           return;
         }
 


### PR DESCRIPTION
## Summary
- allow players to register immediately when the hall of fame has no existing records by skipping comparison
- display the name entry form with a message indicating they can take the first spot

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d54926f8fc833292f7804278ac9677