### PR TITLE
Prevent explosion effect from damaging bosses

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -3474,6 +3474,10 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         for (let i = enemies.length - 1; i >= 0; i--) {
           const e = enemies[i];
           if (!e.entered) continue;
+          if (e.isBoss) {
+            // 보스 몬스터는 폭발 효과의 영향을 받지 않음
+            continue;
+          }
           const ex = e.x + e.w / 2;
           const ey = e.y + e.h / 2;
           const dist = Math.hypot(ex - cx, ey - cy);


### PR DESCRIPTION
## Summary
- stop applying explosion damage to boss enemies so they are unaffected by player-triggered explosions
- document the behavior with an inline comment for future clarity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d624f4984c8332b6a40fb8a71f09b4