### PR TITLE
Allow sword knockback upgrade to affect tank enemies

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -3677,10 +3677,19 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
                 score += e.reward;
                 continue;
               }
-              if (!e.knockbackImmune) {
+              const hasSwordKnockbackUpgrade =
+                baseAttack === "sword" && (acquiredUpgrades["knockback"] || 0) > 0;
+              const isDefenseType = e.type && e.type.id === "tank";
+              const knockbackMultiplier = !e.knockbackImmune
+                ? 1
+                : hasSwordKnockbackUpgrade && isDefenseType
+                ? 0.5
+                : 0;
+              if (knockbackMultiplier > 0) {
                 const nx = player.dir;
                 e.knockbackVx =
-                  (e.knockbackVx || 0) + nx * swordKnockback * enemyKnockbackFriction;
+                  (e.knockbackVx || 0) +
+                  nx * swordKnockback * enemyKnockbackFriction * knockbackMultiplier;
                 e.vy = -enemyKnockbackLift;
               }
             }


### PR DESCRIPTION
## Summary
- allow sword knockback upgrades for the sword to apply partial knockback against tank enemies that are normally immune

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d94a5a39fc8332bf67a5e0072f13db