### PR TITLE
Guard boss removal during explosions

### DIFF
--- a/warigari_survivor.html
+++ b/warigari_survivor.html
@@ -5750,7 +5750,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             continue;
           }
 
-          if ((e.hp ?? 0) <= 0 || e._killed) {
+          if ((e.hp ?? 0) <= 0 || (!e.isBoss && e._killed)) {
             if (!e._killed) {
               if (e.entered) {
                 dropExpOrbs(e);
@@ -5945,6 +5945,13 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
                 }
                 spawnFloatText(ex, e.y - 12, -(dmg + extra), "#ff6b6b");
                 if (explosionEnabled && !enemies.includes(e)) {
+                  if (e.isBoss) {
+                    console.warn(
+                      "Boss unexpectedly removed from enemies during bullet explosion",
+                      e,
+                    );
+                    break;
+                  }
                   e._killed = true;
                   break;
                 }
@@ -6022,6 +6029,13 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
                 }
                 spawnFloatText(ex, e.y - 12, -(dmg + extra), "#ff6b6b");
                 if (explosionEnabled && !enemies.includes(e)) {
+                  if (e.isBoss) {
+                    console.warn(
+                      "Boss unexpectedly removed from enemies during yoyo explosion",
+                      e,
+                    );
+                    break;
+                  }
                   e._killed = true;
                   break;
                 }


### PR DESCRIPTION
## Summary
- prevent explosion follow-up effects from marking bosses as killed when they are removed from the enemy list
- log a warning if a boss unexpectedly leaves the enemy list during bullet or yoyo explosions
- ensure main enemy cleanup only honors the killed flag for non-boss enemies

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de74e3e5988332a1498666fd091ad4